### PR TITLE
feat!: provide input via stdin and as an argument

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -164,6 +164,7 @@ ls | sort
 				return err
 			}
 
+			var promptBuilder strings.Builder
 			var prompt, input string
 			mode := "txt"
 
@@ -178,12 +179,33 @@ ls | sort
 					slog.Debug("No input via pipe provided")
 					return ErrMissingInput
 				}
-				prompt = input
-				// mode is provided via command line args
-				if len(args) == 1 {
-					slog.Debug("Mode provided via command line args")
-					mode = args[0]
+				_, err = promptBuilder.WriteString(input)
+				if err != nil {
+					return err
 				}
+
+				// check if args are provided
+				if len(args) == 0 {
+					// no mode or prompt provided via command line args
+					slog.Debug("No mode or additional prompt provided via command line args")
+
+				} else if len(args) == 1 {
+					// additional prompt was provided via command line args
+					slog.Debug("Additional prompt provided via command line args")
+					_, err = promptBuilder.WriteString("\n\n" + args[0])
+					if err != nil {
+						return err
+					}
+
+				} else {
+					// mode and additional prompt were provided via command line args
+					mode = strings.ToLower(args[0])
+					_, err = promptBuilder.WriteString("\n\n" + args[1])
+					if err != nil {
+						return err
+					}
+				}
+				prompt = promptBuilder.String()
 
 			} else {
 				// input is provided via command line args

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,12 +29,14 @@ $ sgpt "mass of sun"
 The mass of the sun is approximately 1.989 x 10^30 kilograms.
 ```
 
-You can also pass prompts to SGPT using pipes:
+In addition, you can pass a file via pipes and add your prompt to ask a question about the file or have it summarized
+for you.
 
 ```shell
-$ echo -n "mass of sun" | sgpt
-The mass of the sun is approximately 1.989 x 10^30 kilograms.
+cat yourfile.txt | sgpt "summarize everything above"
 ```
+
+The prompt passed as an argument is appended to the data that is piped in.
 
 ## Code Generation Capabilities
 

--- a/docs/usage/query-models.md
+++ b/docs/usage/query-models.md
@@ -9,19 +9,22 @@ $ sgpt "mass of sun"
 The mass of the sun is approximately 1.989 x 10^30 kilograms.
 ```
 
-You can also pass prompts to SGPT using pipes:
-
-```shell
-$ echo -n "mass of sun" | sgpt
-The mass of the sun is approximately 1.989 x 10^30 kilograms.
-```
-
 You can also use the `--clipboard` flag to write the answer to the clipboard:
 
 ```shell
 $ sgpt --clipboard "mass of sun"
 The mass of the sun is approximately 1.989 x 10^30 kilograms.
 ```
+
+In addition, you can pass a file via pipes and add your prompt to ask a question about the file or have it summarized
+for you.
+
+```shell
+cat yourfile.txt | sgpt "summarize everything above"
+```
+
+The prompt passed as an argument is appended to the data that is piped in. Keep in mind: Depending on the model you are
+using, there are different limits to the number of tokens you can use in your prompt.
 
 ## Generate Code
 

--- a/modifiers/prompts.yml
+++ b/modifiers/prompts.yml
@@ -27,7 +27,7 @@
   messages:
     - role: system
       text: |-
-        Act as a natural language to {{ with .SHELL -}}{{ . }}{{ end -}} command translation engine on {{.OS}}.
+        Act as a natural language to {{ with .SHELL -}}{{ . }} {{ end -}} command translation engine on {{.OS}}.
         You are an expert {{if .SHELL -}}in {{ .SHELL }} on {{.OS}} {{ else -}} in {{.OS}} {{ end -}}and translate the question at the end to valid syntax.
         Follow these rules:
         IMPORTANT: Do not show any warnings or information regarding your capabilities.


### PR DESCRIPTION
Provide your prompt via stdin and add additional descriptions via an argument.

- If one argument exists, it is expected to be an additional prompt.
- If two arguments exists, the first arg is the persona and the second arg is the additional prompt.