### PR TITLE
fix: config init writes unnecessary values to config file

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,7 +162,8 @@ tasks:
   ci:
     desc: Run all CI steps
     cmds:
-      - task: setup
+      - task: clean
+      - task: prepare
       - task: build
       - task: test
 

--- a/api/api.go
+++ b/api/api.go
@@ -28,9 +28,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/tbckr/sgpt/v2/chat"
+
 	"github.com/sashabaranov/go-openai"
 	"github.com/spf13/viper"
-	"github.com/tbckr/sgpt/v2/chat"
 	"github.com/tbckr/sgpt/v2/modifiers"
 )
 
@@ -85,7 +86,7 @@ func CreateClient() (*OpenAIClient, error) {
 	return client, nil
 }
 
-func (c *OpenAIClient) GetChatCompletion(ctx context.Context, config *viper.Viper, prompt, modifier string) (string, error) {
+func (c *OpenAIClient) GetChatCompletion(ctx context.Context, config *viper.Viper, chatID, prompt, modifier string) (string, error) {
 	var err error
 	var chatSessionManager chat.SessionManager
 	var messages []openai.ChatCompletionMessage
@@ -95,10 +96,8 @@ func (c *OpenAIClient) GetChatCompletion(ctx context.Context, config *viper.Vipe
 		return "", err
 	}
 
-	var chatID string
-	var isChat bool
-	if config.IsSet("chat") {
-		chatID = config.GetString("chat")
+	isChat := false
+	if chatID != "" {
 		isChat = true
 	}
 	chatExists := false

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -91,7 +91,7 @@ func TestSimplePrompt(t *testing.T) {
 	config := createTestConfig(t)
 
 	var result string
-	result, err = client.GetChatCompletion(context.Background(), config, prompt, "txt")
+	result, err = client.GetChatCompletion(context.Background(), config, "", prompt, "txt")
 	require.NoError(t, err)
 	require.Equal(t, expected, result)
 
@@ -117,10 +117,8 @@ func TestPromptSaveAsChat(t *testing.T) {
 	require.NoError(t, err)
 	config := createTestConfig(t)
 
-	config.Set("chat", "test_chat")
-
 	var result string
-	result, err = client.GetChatCompletion(context.Background(), config, prompt, "txt")
+	result, err = client.GetChatCompletion(context.Background(), config, "test_chat", prompt, "txt")
 	require.NoError(t, err)
 	require.Equal(t, expected, result)
 
@@ -152,8 +150,6 @@ func TestPromptLoadChat(t *testing.T) {
 	require.NoError(t, err)
 	config := createTestConfig(t)
 
-	config.Set("chat", "test_chat")
-
 	var manager chat.SessionManager
 	manager, err = chat.NewFilesystemChatSessionManager(config)
 	require.NoError(t, err)
@@ -171,7 +167,7 @@ func TestPromptLoadChat(t *testing.T) {
 	require.NoError(t, err)
 
 	var result string
-	result, err = client.GetChatCompletion(context.Background(), config, prompt, "txt")
+	result, err = client.GetChatCompletion(context.Background(), config, "test_chat", prompt, "txt")
 	require.NoError(t, err)
 	require.Equal(t, expected, result)
 
@@ -206,7 +202,7 @@ func TestPromptWithModifier(t *testing.T) {
 	config.Set("chat", "test_chat")
 
 	var result string
-	result, err = client.GetChatCompletion(context.Background(), config, prompt, "sh")
+	result, err = client.GetChatCompletion(context.Background(), config, "test_chat", prompt, "sh")
 	require.NoError(t, err)
 	require.Equal(t, expected, result)
 

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -56,6 +56,13 @@ func TestConfigCmdInit(t *testing.T) {
 	require.Equal(t, 0, mem.code)
 
 	require.FileExists(t, filepath.Join(configDir, "config.yaml"))
+	// config must only contain values for model, maxtokens, temperature, topp
+	require.NoError(t, config.ReadInConfig())
+	// TESTING may be in the config, because this is a test
+	require.Equal(t, 5, len(config.AllSettings()))
+	for _, key := range []string{"model", "maxtokens", "temperature", "topp", "testing"} {
+		require.Contains(t, config.AllSettings(), key)
+	}
 }
 
 func TestConfigCmdInitAlreadyExists(t *testing.T) {


### PR DESCRIPTION
Extract values that are not in the config file to flags only, and do not bind them to the config file.