### PR TITLE
feat: override API base url via env var

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -75,8 +75,18 @@ func CreateClient() (*OpenAIClient, error) {
 	if !exists {
 		return nil, ErrMissingAPIKey
 	}
+	clientConfig := openai.DefaultConfig(apiKey)
+
+	// Check, if API base url was set
+	baseURL, isSet := os.LookupEnv("OPENAI_API_BASE")
+	if isSet {
+		// Set base url
+		clientConfig.BaseURL = baseURL
+		slog.Debug("Setting API base url to " + baseURL)
+	}
+	// Create client
 	client := &OpenAIClient{
-		api: openai.NewClient(apiKey),
+		api: openai.NewClientWithConfig(clientConfig),
 		// This is necessary to be able to mock the api in tests
 		retrieveResponseFn: func(api *openai.Client, ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
 			return api.CreateChatCompletion(ctx, req)

--- a/docs/usage/query-models.md
+++ b/docs/usage/query-models.md
@@ -61,3 +61,11 @@ $ sgpt sh --execute "make all files in current directory read only"
 chmod -R 444 *
 Do you want to execute this command? (Y/n) y
 ```
+
+## Override OpenAI API base URL
+
+You can override the OpenAI base URL by setting the `OPENAI_API_BASE` environment variable:
+
+```shell
+export OPENAI_API_BASE=https://api.openai.com/v1
+```


### PR DESCRIPTION
Override the OpenAI API base url by setting the OPENAI_API_BASE environment variable.