### PR TITLE
Fixed config location on MacOS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 SGPT can be configured via a config file in your default config directory. The default config directory
-is `~/.config/sgpt/` on Linux and MacOS and `%APPDATA%/sgpt/` on Windows. The config file is named `config.yaml`.
+is `~/.config/sgpt/` on Linux, `~/Library/Application Support/sgpt/` on MacOS and `%APPDATA%/sgpt/` on Windows. The config file is named `config.yaml`.
 
 The config file is a YAML file with the following structure:
 


### PR DESCRIPTION
The listed config location did not appear to be up-to-date, at least for MacOS. This might be an issue on Linux as well.

<!-- markdownlint-disable MD041 -->

<!-- If applied, this commit will... -->
Update the documentation.

<!-- Why is this change being made? -->
The config.yaml appears to be in a different location now, at least on MaOS. To reproduce: install with `brew`, execute `sgpt init` and try to find the config file.

