### PR TITLE
feat: add example ansible playbook as install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,38 @@ docker pull ghcr.io/tbckr/sgpt:latest
 
 Examples on how to use SGPT with Docker can be found [here](https://sgpt.readthedocs.io/en/latest/usage/docker/).
 
+### Ansible
+
+To install SGPT with Ansible, you can use the following ansible playbook as your base and adapt accordingly:
+
+```yaml
+---
+- hosts: all
+  tasks:
+  - name: Get latest sgpt release
+    uri:
+      url: "https://api.github.com/repos/tbckr/sgpt/releases/latest"
+      return_content: yes
+    register: sgpt_release
+
+  - name: Set latest version of sgpt
+    set_fact:
+      sgpt_latest_version: "{{ sgpt_release.json.tag_name }}"
+
+  - name: Install sgpt for amd64 based systems on Linux
+    ansible.builtin.apt:
+      deb: https://github.com/tbckr/sgpt/releases/download/{{ sgpt_latest_version }}/sgpt_{{ sgpt_latest_version[1:] }}_amd64.deb
+      allow_unauthenticated: true
+```
+
+The playbook can be run with the following command:
+
+```shell
+ansible-playbook -i <inventory> <playbook>.yml
+```
+
+The latest version of the playbook can be found [here](https://github.com/tbckr/sgpt/blob/main/playbook.yml).
+
 ### Other platforms
 
 For other platforms, visit the GitHub [release page](https://github.com/tbckr/sgpt/releases) and download the latest

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To install SGPT with Ansible, you can use the following ansible playbook as your
     set_fact:
       sgpt_latest_version: "{{ sgpt_release.json.tag_name }}"
 
-  - name: Install sgpt for amd64 based systems on Linux
+  - name: Install sgpt for debian based, amd64 systems
     ansible.builtin.apt:
       deb: https://github.com/tbckr/sgpt/releases/download/{{ sgpt_latest_version }}/sgpt_{{ sgpt_latest_version[1:] }}_amd64.deb
       allow_unauthenticated: true

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,38 @@ To run SGPT with Docker, use the following command to pull the latest image:
 docker pull ghcr.io/tbckr/sgpt:latest
 ```
 
+## Ansible
+
+To install SGPT with Ansible, you can use the following ansible playbook as your base and adapt accordingly:
+
+```yaml
+---
+- hosts: all
+  tasks:
+  - name: Get latest sgpt release
+    uri:
+      url: "https://api.github.com/repos/tbckr/sgpt/releases/latest"
+      return_content: yes
+    register: sgpt_release
+
+  - name: Set latest version of sgpt
+    set_fact:
+      sgpt_latest_version: "{{ sgpt_release.json.tag_name }}"
+
+  - name: Install sgpt for amd64 based systems on Linux
+    ansible.builtin.apt:
+      deb: https://github.com/tbckr/sgpt/releases/download/{{ sgpt_latest_version }}/sgpt_{{ sgpt_latest_version[1:] }}_amd64.deb
+      allow_unauthenticated: true
+```
+
+The playbook can be run with the following command:
+
+```shell
+ansible-playbook -i <inventory> <playbook>.yml
+```
+
+The latest version of the playbook can be found [here](https://github.com/tbckr/sgpt/blob/main/playbook.yml).
+
 ## Other platforms
 
 For other platforms, visit the GitHub [release page](https://github.com/tbckr/sgpt/releases) and download the latest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,7 +64,7 @@ To install SGPT with Ansible, you can use the following ansible playbook as your
     set_fact:
       sgpt_latest_version: "{{ sgpt_release.json.tag_name }}"
 
-  - name: Install sgpt for amd64 based systems on Linux
+  - name: Install sgpt for debian based, amd64 systems
     ansible.builtin.apt:
       deb: https://github.com/tbckr/sgpt/releases/download/{{ sgpt_latest_version }}/sgpt_{{ sgpt_latest_version[1:] }}_amd64.deb
       allow_unauthenticated: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -32,7 +32,7 @@
     set_fact:
       sgpt_latest_version: "{{ sgpt_release.json.tag_name }}"
 
-  - name: Install sgpt for amd64 based systems on Linux
+  - name: Install sgpt for debian based, amd64 systems
     ansible.builtin.apt:
       deb: https://github.com/tbckr/sgpt/releases/download/{{ sgpt_latest_version }}/sgpt_{{ sgpt_latest_version[1:] }}_amd64.deb
       allow_unauthenticated: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Tim <tbckr>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- hosts: all
+  tasks:
+  - name: Get latest sgpt release
+    uri:
+      url: "https://api.github.com/repos/tbckr/sgpt/releases/latest"
+      return_content: yes
+    register: sgpt_release
+
+  - name: Set latest version of sgpt
+    set_fact:
+      sgpt_latest_version: "{{ sgpt_release.json.tag_name }}"
+
+  - name: Install sgpt for amd64 based systems on Linux
+    ansible.builtin.apt:
+      deb: https://github.com/tbckr/sgpt/releases/download/{{ sgpt_latest_version }}/sgpt_{{ sgpt_latest_version[1:] }}_amd64.deb
+      allow_unauthenticated: true


### PR DESCRIPTION
Adds example ansible playbook for installing SGPT on debian based systems.