### PR TITLE
feat: use distroless base images for docker

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,7 +49,6 @@ builds:
       - windows
       - darwin
     goarch:
-      - "386"
       - "amd64"
       - "arm"
       - "arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,29 +19,16 @@
 #
 # SPDX-License-Identifier: MIT
 
-ARG IMAGE_1=cgr.dev/chainguard/go:1.21@sha256:f807658ebd070455c2ec930407fb4427c0761f5401c5c84e9b0dac3ee99c1da8
-ARG IMAGE_2=cgr.dev/chainguard/static:latest@sha256:a2f525dac2f9ec900283ead64eb88a6037b2989630615ee8de8a2dc7bfcf152b
+ARG BUILDPLATFORM=linux/amd64
+ARG BASE_IMAGE_VERSION=golang:1.21
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE_VERSION} as build
 
-FROM --platform=$BUILDPLATFORM ${IMAGE_1} as build
-
-WORKDIR /work
-
+WORKDIR /go/src/github.com/tbckr/sgpt
 COPY go.mod go.sum ./
 RUN go mod download
-
 COPY . .
-ARG TARGETOS TARGETARCH TARGETVARIANT
-RUN \
-    if [ "${TARGETARCH}" = "arm" ] && [ -n "${TARGETVARIANT}" ]; then \
-      export GOARM="${TARGETVARIANT#v}"; \
-    fi; \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o sgpt -v ./cmd/sgpt/main.go
+RUN CGO_ENABLED=0 go build -o sgpt -v ./cmd/sgpt/main.go
 
-
-FROM ${IMAGE_2}
-
-ENV HOME /home/nonroot
-VOLUME /home/nonroot
-
-COPY --from=build /work/sgpt /sgpt
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /go/src/github.com/tbckr/sgpt/sgpt /sgpt
 ENTRYPOINT ["/sgpt"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,5 @@
-FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/static:latest@sha256:a2f525dac2f9ec900283ead64eb88a6037b2989630615ee8de8a2dc7bfcf152b
-
-ENV HOME /home/nonroot
-VOLUME /home/nonroot
-
+ARG BUILDPLATFORM=linux/amd64
+ARG BASE_IMAGE_VERSION=gcr.io/distroless/static-debian12:nonroot
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE_VERSION}
 COPY sgpt /sgpt
 ENTRYPOINT ["/sgpt"]


### PR DESCRIPTION
Chainguard stopped publishing all docker images publicly. Therefore, we are going to use distroless images instead.

This also drops support for 389 architectures