### PR TITLE
fix: set missing role of received message

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -158,6 +158,11 @@ func (c *OpenAIClient) CreateCompletion(ctx context.Context, chatID, prompt, mod
 	if err != nil {
 		return "", err
 	}
+	// Set role of received message, if not set
+	// This seems to be a bug in the OpenAI API for now
+	if receivedMessage.Role == "" {
+		receivedMessage.Role = openai.ChatMessageRoleAssistant
+	}
 
 	slog.Debug("Received message from OpenAI API")
 


### PR DESCRIPTION
this seems to be a bug in the OpenAI API or library (?) as the role is missing in the returned assistant message.

this is a workaround.