### PR TITLE
fix: update go version to 1.22.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       # Install various tools
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: '>=1.22.3'
+          go-version-file: go.mod
           cache: true
       - name: setup-tparse
         run: |
@@ -110,7 +110,7 @@ jobs:
       # Install Go
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: '>=1.22.3'
+          go-version-file: go.mod
           cache: true
       # Run linter
       - name: golangci-lint
@@ -130,8 +130,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
+          go-version-file: go.mod
           cache: true
-          go-version: '>=1.22.3'
       - name: govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         if: ${{ steps.release.outputs.release_created }}
         with:
-          go-version: '>=1.22.3'
+          go-version-file: go.mod
           cache: true
       - uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
         if: ${{ steps.release.outputs.release_created }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tbckr/sgpt/v2
 
-go 1.22.2
+go 1.22.5
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
Updates go version to 1.22.5 in go mod file.

Use go mod file to setup to setup correct go version in CI pipelines.