### PR TITLE
fix: fix chat subcommands

### DIFF
--- a/pkg/cli/chat.go
+++ b/pkg/cli/chat.go
@@ -72,6 +72,9 @@ Manage all open chat sessions - list, show, and delete chat sessions.
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.NoArgs,
 		ValidArgsFunction:     cobra.NoFileCompletions,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return loadViperConfig(config)
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},


### PR DESCRIPTION
all of the sgpt chat subcommands (like cat, ls, rm) were broken. the viper config was not loaded, which included the user cache dir. the user cache dir is used to save the chat sessions.