### PR TITLE
fix: fix env isolation and add DI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Custom
 /.idea
+CLAUDE.md
+.claude/
+di.md
 
 dist/
 manpages/

--- a/internal/testlib/env.go
+++ b/internal/testlib/env.go
@@ -21,18 +21,17 @@
 
 package testlib
 
-import (
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/stretchr/testify/require"
-)
-
+// SetAPIKey sets OPENAI_API_KEY to a test value and restores the original on cleanup.
 func SetAPIKey(t *testing.T) {
-	err := os.Setenv("OPENAI_API_KEY", "test")
-	require.NoError(t, err)
+	t.Helper()
+	t.Setenv("OPENAI_API_KEY", "test")
+}
 
-	t.Cleanup(func() {
-		_ = os.Unsetenv("OPENAI_API_KEY")
-	})
+// SetAPIBase pins OPENAI_API_BASE to the URL httpmock registers against so that
+// tests pass regardless of what the developer has set in their shell.
+func SetAPIBase(t *testing.T) {
+	t.Helper()
+	t.Setenv("OPENAI_API_BASE", "https://api.openai.com/v1")
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -53,6 +53,24 @@ var (
 	ErrEmptyResponse = errors.New("no choices returned in API response")
 )
 
+// Completer is the interface that wraps the CreateCompletion method.
+// It is satisfied by *OpenAIClient and allows CLI code to depend on an
+// abstraction rather than the concrete type, enabling lightweight fakes in tests.
+type Completer interface {
+	CreateCompletion(ctx context.Context, chatID string, prompt []string, modifier string, input []string) (string, error)
+}
+
+// ClientOption is a functional option for configuring an OpenAIClient.
+type ClientOption func(*OpenAIClient)
+
+// WithSessionManager injects a custom SessionManager into the client.
+// When not provided, CreateClient creates a FilesystemChatSessionManager automatically.
+func WithSessionManager(sm chat.SessionManager) ClientOption {
+	return func(c *OpenAIClient) {
+		c.chatSessionManager = sm
+	}
+}
+
 // OpenAIClient is a client for the OpenAI API.
 type OpenAIClient struct {
 	HTTPClient         *http.Client
@@ -63,7 +81,8 @@ type OpenAIClient struct {
 }
 
 // CreateClient creates a new OpenAI client with the given config and output writer.
-func CreateClient(config *viper.Viper, out io.Writer) (*OpenAIClient, error) {
+// Optional ClientOptions can be passed to override defaults (e.g. WithSessionManager).
+func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*OpenAIClient, error) {
 	// Check, if api key was set
 	apiKey, exists := os.LookupEnv(envKeyOpenAIApi)
 	if !exists {
@@ -88,21 +107,27 @@ func CreateClient(config *viper.Viper, out io.Writer) (*OpenAIClient, error) {
 		slog.Debug("Setting API base url to " + baseURL)
 	}
 
-	// Initialize chat session manager
-	chatSessionManager, err := chat.NewFilesystemChatSessionManager(config)
-	if err != nil {
-		return nil, err
-	}
-	slog.Debug("Chat session manager initialized")
-
-	// Create client
+	// Build client and apply options
 	client := &OpenAIClient{
-		HTTPClient:         httpClient,
-		config:             config,
-		api:                openai.NewClientWithConfig(clientConfig),
-		out:                out,
-		chatSessionManager: chatSessionManager,
+		HTTPClient: httpClient,
+		config:     config,
+		api:        openai.NewClientWithConfig(clientConfig),
+		out:        out,
 	}
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	// Fall back to filesystem-backed session manager if none was injected
+	if client.chatSessionManager == nil {
+		chatSessionManager, err := chat.NewFilesystemChatSessionManager(config)
+		if err != nil {
+			return nil, err
+		}
+		client.chatSessionManager = chatSessionManager
+		slog.Debug("Chat session manager initialized")
+	}
+
 	slog.Debug("OpenAI client created")
 	return client, nil
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -39,21 +39,26 @@ import (
 )
 
 func TestCreateClient(t *testing.T) {
-	// Set the api key
-	err := os.Setenv("OPENAI_API_KEY", "test")
-	require.NoError(t, err)
+	t.Setenv("OPENAI_API_KEY", "test")
 
 	var client *OpenAIClient
+	var err error
 	client, err = CreateClient(nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 }
 
 func TestCreateClientMissingApiKey(t *testing.T) {
-	err := os.Unsetenv("OPENAI_API_KEY")
-	require.NoError(t, err)
+	prev, had := os.LookupEnv("OPENAI_API_KEY")
+	require.NoError(t, os.Unsetenv("OPENAI_API_KEY"))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENAI_API_KEY", prev)
+		}
+	})
 
 	var client *OpenAIClient
+	var err error
 	client, err = CreateClient(nil, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrMissingAPIKey)
@@ -63,6 +68,7 @@ func TestCreateClientMissingApiKey(t *testing.T) {
 func TestSimplePrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -112,6 +118,7 @@ func TestSimplePrompt(t *testing.T) {
 func TestStreamSimplePrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -150,6 +157,7 @@ func TestStreamSimplePrompt(t *testing.T) {
 func TestPromptSaveAsChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -205,6 +213,7 @@ func TestPromptSaveAsChat(t *testing.T) {
 func TestPromptLoadChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -270,6 +279,7 @@ func TestPromptLoadChat(t *testing.T) {
 func TestPromptWithModifier(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -285,11 +295,7 @@ func TestPromptWithModifier(t *testing.T) {
 	t.Cleanup(httpmock.DeactivateAndReset)
 	testlib.RegisterExpectedChatResponse(response)
 
-	err = os.Setenv("SHELL", "/bin/bash")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv("SHELL"))
-	})
+	t.Setenv("SHELL", "/bin/bash")
 
 	testCtx.Config.Set("chat", "test_chat")
 
@@ -337,6 +343,7 @@ func TestPromptWithModifier(t *testing.T) {
 func TestSimplePromptWithLocalImage(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -374,6 +381,7 @@ func TestSimplePromptWithLocalImage(t *testing.T) {
 func TestSimplePromptWithLocalImageAndChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -439,6 +447,7 @@ func TestSimplePromptWithLocalImageAndChat(t *testing.T) {
 func TestSimplePromptWithURLImageAndChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -503,6 +512,7 @@ func TestSimplePromptWithURLImageAndChat(t *testing.T) {
 func TestSimplePromptWithHTTPURLImageAndChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -567,6 +577,7 @@ func TestSimplePromptWithHTTPURLImageAndChat(t *testing.T) {
 func TestSimplePromptWithMixedImagesAndChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()
@@ -637,6 +648,7 @@ func TestSimplePromptWithMixedImagesAndChat(t *testing.T) {
 func TestSimplePrompt_EmptyChoices(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 
 	var wg sync.WaitGroup
 	reader, writer := io.Pipe()

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -36,7 +36,7 @@ type checkCmd struct {
 	cmd *cobra.Command
 }
 
-func newCheckCmd(config *viper.Viper, createClientFn func(*viper.Viper, io.Writer) (*api.OpenAIClient, error)) *checkCmd {
+func newCheckCmd(config *viper.Viper, createClientFn func(*viper.Viper, io.Writer) (api.Completer, error)) *checkCmd {
 	check := &checkCmd{}
 	cmd := &cobra.Command{
 		Use:   "check",

--- a/pkg/cli/check_test.go
+++ b/pkg/cli/check_test.go
@@ -22,13 +22,14 @@
 package cli
 
 import (
+	"io"
+	"os"
 	"testing"
 
-	"github.com/tbckr/sgpt/v2/pkg/api"
-
-	"github.com/tbckr/sgpt/v2/internal/testlib"
-
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"github.com/tbckr/sgpt/v2/internal/testlib"
+	"github.com/tbckr/sgpt/v2/pkg/api"
 )
 
 func TestCheckCmd(t *testing.T) {
@@ -36,9 +37,9 @@ func TestCheckCmd(t *testing.T) {
 	testlib.SetAPIKey(t)
 	mem := &exitMemento{}
 
-	testlib.SetAPIKey(t)
-
-	newRootCmd(mem.Exit, testCtx.Config, mockIsPipedShell(false, nil), api.CreateClient).Execute([]string{"check"})
+	newRootCmd(mem.Exit, testCtx.Config, mockIsPipedShell(false, nil), func(v *viper.Viper, w io.Writer) (api.Completer, error) {
+		return api.CreateClient(v, w)
+	}).Execute([]string{"check"})
 	require.Equal(t, 0, mem.code)
 }
 
@@ -46,6 +47,17 @@ func TestCheckCmdUnsetEnvAPIKey(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	mem := &exitMemento{}
 
-	newRootCmd(mem.Exit, testCtx.Config, mockIsPipedShell(false, nil), api.CreateClient).Execute([]string{"check"})
+	// Ensure OPENAI_API_KEY is absent for this test regardless of the shell environment.
+	prev, had := os.LookupEnv("OPENAI_API_KEY")
+	require.NoError(t, os.Unsetenv("OPENAI_API_KEY"))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENAI_API_KEY", prev)
+		}
+	})
+
+	newRootCmd(mem.Exit, testCtx.Config, mockIsPipedShell(false, nil), func(v *viper.Viper, w io.Writer) (api.Completer, error) {
+		return api.CreateClient(v, w)
+	}).Execute([]string{"check"})
 	require.Equal(t, 1, mem.code)
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -69,7 +69,9 @@ func Execute(args []string) {
 		slog.Error("Failed to create viper config", "error", err)
 		os.Exit(1)
 	}
-	newRootCmd(os.Exit, viperConfig, shell.IsPipedShell, api.CreateClient).Execute(args)
+	newRootCmd(os.Exit, viperConfig, shell.IsPipedShell, func(v *viper.Viper, w io.Writer) (api.Completer, error) {
+		return api.CreateClient(v, w)
+	}).Execute(args)
 }
 
 func (r *rootCmd) Execute(args []string) {
@@ -105,7 +107,7 @@ func (r *rootCmd) Execute(args []string) {
 	r.exit(0)
 }
 
-func newRootCmd(exit func(int), config *viper.Viper, isPipedShell func() (bool, error), createClientFn func(*viper.Viper, io.Writer) (*api.OpenAIClient, error)) *rootCmd {
+func newRootCmd(exit func(int), config *viper.Viper, isPipedShell func() (bool, error), createClientFn func(*viper.Viper, io.Writer) (api.Completer, error)) *rootCmd {
 	root := &rootCmd{
 		exit: exit,
 	}
@@ -261,7 +263,7 @@ $ echo "lang: Python" | sgpt code --template "Write a hello world program in {{ 
 			}
 
 			// Create client
-			var client *api.OpenAIClient
+			var client api.Completer
 			client, err = createClientFn(config, cmd.OutOrStdout())
 			if err != nil {
 				return err

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -548,6 +549,9 @@ func TestRootCmd_SimpleShellPrompt(t *testing.T) {
 }
 
 func TestRootCmd_SimpleShellPromptWithExecution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell execution requires bash and is not supported on Windows")
+	}
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
 	testlib.SetAPIBase(t)

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -47,6 +47,7 @@ import (
 func TestRootCmd_SimplePrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -86,6 +87,7 @@ func TestRootCmd_SimplePrompt(t *testing.T) {
 func TestRootCmd_SimplePromptOnly(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -127,6 +129,7 @@ func TestRootCmd_SimpleClipboard(t *testing.T) {
 
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -170,6 +173,7 @@ func TestRootCmd_SimpleClipboard(t *testing.T) {
 func TestRootCmd_SimplePromptOverrideValuesWithConfigFile(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -218,6 +222,7 @@ func TestRootCmd_SimplePromptOverrideValuesWithConfigFile(t *testing.T) {
 func TestRootCmd_SimplePromptNoPrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	client, err := api.CreateClient(testCtx.Config, nil)
@@ -232,6 +237,7 @@ func TestRootCmd_SimplePromptNoPrompt(t *testing.T) {
 func TestRootCmd_SimplePromptVerbose(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -271,6 +277,7 @@ func TestRootCmd_SimplePromptVerbose(t *testing.T) {
 func TestRootCmd_SimplePromptViaPipedShell(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -321,6 +328,7 @@ func TestRootCmd_SimplePromptViaPipedShell(t *testing.T) {
 func TestRootCmd_PipedShell_NoInput(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -363,6 +371,7 @@ func TestRootCmd_PipedShell_NoInput(t *testing.T) {
 func TestRootCmd_SimplePrompt_PipedShellError(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -396,6 +405,7 @@ func TestRootCmd_SimplePrompt_PipedShellError(t *testing.T) {
 func TestRootCmd_SimplePromptViaPipedShellAndModifier(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -446,6 +456,7 @@ func TestRootCmd_SimplePromptViaPipedShellAndModifier(t *testing.T) {
 func TestRootCmd_PipedShellAndModifierAndPrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -497,6 +508,7 @@ func TestRootCmd_PipedShellAndModifierAndPrompt(t *testing.T) {
 func TestRootCmd_SimpleShellPrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -513,11 +525,7 @@ func TestRootCmd_SimpleShellPrompt(t *testing.T) {
 	t.Cleanup(httpmock.DeactivateAndReset)
 	testlib.RegisterExpectedChatResponse(response)
 
-	err = os.Setenv("SHELL", "/bin/bash")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv("SHELL"))
-	})
+	t.Setenv("SHELL", "/bin/bash")
 
 	root := newRootCmd(mem.Exit, testCtx.Config, mockIsPipedShell(false, nil), useMockClient(client))
 	root.cmd.SetOut(writer)
@@ -542,6 +550,7 @@ func TestRootCmd_SimpleShellPrompt(t *testing.T) {
 func TestRootCmd_SimpleShellPromptWithExecution(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -559,11 +568,7 @@ func TestRootCmd_SimpleShellPromptWithExecution(t *testing.T) {
 	t.Cleanup(httpmock.DeactivateAndReset)
 	testlib.RegisterExpectedChatResponse(response)
 
-	err = os.Setenv("SHELL", "/bin/bash")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.Unsetenv("SHELL")
-	})
+	t.Setenv("SHELL", "/bin/bash")
 
 	root := newRootCmd(mem.Exit, testCtx.Config, mockIsPipedShell(false, nil), useMockClient(client))
 	root.cmd.SetIn(stdinReader)
@@ -600,6 +605,7 @@ func TestRootCmd_SimpleShellPromptWithExecution(t *testing.T) {
 func TestRootCmd_SimplePromptWithChat(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -657,6 +663,7 @@ func TestRootCmd_SimplePromptWithChat(t *testing.T) {
 func TestRootCmd_SimplePromptWithChatAndCustomPersona(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -674,11 +681,7 @@ func TestRootCmd_SimplePromptWithChatAndCustomPersona(t *testing.T) {
 	t.Cleanup(httpmock.DeactivateAndReset)
 	testlib.RegisterExpectedChatResponse(response)
 
-	err = os.Setenv("SHELL", "/bin/bash")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv("SHELL"))
-	})
+	t.Setenv("SHELL", "/bin/bash")
 
 	var fileHandler *os.File
 	fileHandler, err = os.Create(filepath.Join(testCtx.Config.GetString("personas"), "my-persona"))
@@ -733,6 +736,7 @@ func TestRootCmd_SimplePromptWithChatAndCustomPersona(t *testing.T) {
 func TestRootCmd_ChatConversation(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -803,10 +807,11 @@ func TestRootCmd_ChatConversation(t *testing.T) {
 func TestRootCmd_PanicRecovery_ExitsWithCode1(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	// Create a client factory that panics
-	panicClientFn := func(_ *viper.Viper, _ io.Writer) (*api.OpenAIClient, error) {
+	panicClientFn := func(_ *viper.Viper, _ io.Writer) (api.Completer, error) {
 		panic("test panic")
 	}
 
@@ -840,6 +845,7 @@ func TestLoadViperConfig_NoTestingFlag(t *testing.T) {
 func TestRootCmd_TemplateWithPipedYAML(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -890,6 +896,7 @@ func TestRootCmd_TemplateWithPipedYAML(t *testing.T) {
 func TestRootCmd_TemplateWithPipedJSON(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -940,6 +947,7 @@ func TestRootCmd_TemplateWithPipedJSON(t *testing.T) {
 func TestRootCmd_TemplateWithPersona(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -991,6 +999,7 @@ func TestRootCmd_TemplateWithPersona(t *testing.T) {
 func TestRootCmd_TemplateNotPiped_Error(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	client, err := api.CreateClient(testCtx.Config, nil)
@@ -1004,6 +1013,7 @@ func TestRootCmd_TemplateNotPiped_Error(t *testing.T) {
 func TestRootCmd_TemplateWithTwoArgs_Error(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	client, err := api.CreateClient(testCtx.Config, nil)
@@ -1021,6 +1031,7 @@ func TestRootCmd_TemplateWithTwoArgs_Error(t *testing.T) {
 func TestRootCmd_TemplateMissingVar_Error(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	var wg sync.WaitGroup
@@ -1050,6 +1061,7 @@ func TestRootCmd_TemplateMissingVar_Error(t *testing.T) {
 func TestRootCmd_TemplateWithExecute_Error(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
 	mem := &exitMemento{}
 
 	client, err := api.CreateClient(testCtx.Config, nil)

--- a/pkg/cli/util_test.go
+++ b/pkg/cli/util_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-var useMockClient = func(mockClient *api.OpenAIClient) func(*viper.Viper, io.Writer) (*api.OpenAIClient, error) {
-	return func(_ *viper.Viper, _ io.Writer) (*api.OpenAIClient, error) {
+var useMockClient = func(mockClient api.Completer) func(*viper.Viper, io.Writer) (api.Completer, error) {
+	return func(_ *viper.Viper, _ io.Writer) (api.Completer, error) {
 		return mockClient, nil
 	}
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -24,6 +24,7 @@ package fs
 import (
 	"io"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -32,6 +33,9 @@ import (
 )
 
 func TestGetAppCacheDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.UserCacheDir() ignores XDG_CACHE_HOME on Windows")
+	}
 	tempDir := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", tempDir)
 
@@ -44,6 +48,9 @@ func TestGetAppCacheDir(t *testing.T) {
 }
 
 func TestGetAppConfigDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.UserConfigDir() ignores XDG_CONFIG_HOME on Windows")
+	}
 	tempDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tempDir)
 

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -23,7 +23,6 @@ package fs
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -33,16 +32,10 @@ import (
 )
 
 func TestGetAppCacheDir(t *testing.T) {
-	existingEnv := os.Getenv("XDG_CACHE_HOME")
-	t.Cleanup(func() {
-		_ = os.Setenv("XDG_CACHE_HOME", existingEnv)
-	})
-
 	tempDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tempDir)
 
-	err := os.Setenv("XDG_CACHE_HOME", tempDir)
-	require.NoError(t, err)
-
+	var err error
 	var cacheDir string
 	cacheDir, err = GetAppCacheDir()
 	require.NoError(t, err)
@@ -51,16 +44,10 @@ func TestGetAppCacheDir(t *testing.T) {
 }
 
 func TestGetAppConfigDir(t *testing.T) {
-	existingEnv := os.Getenv("XDG_CONFIG_HOME")
-	t.Cleanup(func() {
-		_ = os.Setenv("XDG_CACHE_HOME", existingEnv)
-	})
-
 	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
 
-	err := os.Setenv("XDG_CONFIG_HOME", tempDir)
-	require.NoError(t, err)
-
+	var err error
 	var cacheDir string
 	cacheDir, err = GetAppConfigPath()
 	require.NoError(t, err)

--- a/pkg/modifiers/modifiers_test.go
+++ b/pkg/modifiers/modifiers_test.go
@@ -37,11 +37,7 @@ import (
 func TestGetChatModifierShell(t *testing.T) {
 	config := createTestConfig(t)
 
-	err := os.Setenv("SHELL", "/bin/bash")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv("SHELL"))
-	})
+	t.Setenv("SHELL", "/bin/bash")
 
 	modifier, err := GetChatModifier(config, "sh")
 	require.NoError(t, err)
@@ -57,10 +53,12 @@ You are an expert in %s and translate the question at the end to valid syntax.`
 
 	config := createTestConfig(t)
 
-	shellEnv := os.Getenv("SHELL")
+	prevShell, hadShell := os.LookupEnv("SHELL")
 	require.NoError(t, os.Unsetenv("SHELL"))
 	t.Cleanup(func() {
-		require.NoError(t, os.Setenv("SHELL", shellEnv))
+		if hadShell {
+			_ = os.Setenv("SHELL", prevShell)
+		}
 	})
 
 	modifier, err := GetChatModifier(config, "sh")

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -264,6 +265,9 @@ func TestGetUserConfirmationAsked2Times(t *testing.T) {
 }
 
 func TestExecuteShellCommandEcho(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell execution tests require bash and are not supported on Windows")
+	}
 	stdoutReader, stdoutWriter := io.Pipe()
 
 	var wg sync.WaitGroup
@@ -288,6 +292,9 @@ func TestExecuteShellCommandEcho(t *testing.T) {
 }
 
 func TestExecuteCommandWithConfirmation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell execution tests require bash and are not supported on Windows")
+	}
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()
 


### PR DESCRIPTION
## Summary

- **Fix: OPENAI_API_BASE env leak causing 27 test failures** — add `testlib.SetAPIBase(t)` that pins the API base URL to the httpmock-registered URL before client creation; eliminates failures when `OPENAI_API_BASE` is set to a custom host in the developer's shell
- **Fix: unsafe `os.Setenv` patterns replaced with `t.Setenv`** — automatic save/restore on test cleanup; fixes a bug in `TestGetAppConfigDir` that was restoring `XDG_CACHE_HOME` instead of `XDG_CONFIG_HOME`; `TestCheckCmdUnsetEnvAPIKey` now explicitly unsets the key to be robust against real shell environments
- **Refactor: extract `api.Completer` interface** — CLI code now depends on the interface rather than `*OpenAIClient`, enabling lightweight fakes without httpmock
- **Refactor: `SessionManager` injection via functional options** — `CreateClient` accepts `...ClientOption`; `WithSessionManager` allows injecting a custom `chat.SessionManager`; fully backwards-compatible
- **Fix: skip bash/XDG-dependent tests on Windows** — `TestExecuteShellCommandEcho`, `TestExecuteCommandWithConfirmation`, `TestRootCmd_SimpleShellPromptWithExecution`, `TestGetAppCacheDir`, `TestGetAppConfigDir` are skipped on Windows with a clear message; they continue to run in CI on Linux
