### PR TITLE
api: give the OpenAI HTTP transport dial and header timeouts

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -27,9 +27,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/tbckr/sgpt/v2/pkg/fs"
 
@@ -42,6 +44,18 @@ import (
 const (
 	// envKeyOpenAIApi is the environment variable key for the OpenAI API key.
 	envKeyOpenAIApi = "OPENAI_API_KEY"
+
+	// Defaults for the OpenAI HTTP client. Without these, sgpt inherits
+	// http.Client's zero value and can hang indefinitely when the
+	// configured endpoint (OPENAI_API_BASE) is slow or unresponsive,
+	// which is particularly bad in CI/CD pipelines where there is no
+	// interactive recovery path. We intentionally do not set a client-wide
+	// Timeout because sgpt supports streaming responses that can legitimately
+	// stay open for several minutes; ResponseHeaderTimeout is enough to
+	// short-circuit slowloris-style endpoints that never produce headers.
+	defaultDialTimeout           = 10 * time.Second
+	defaultResponseHeaderTimeout = 30 * time.Second
+	defaultTLSHandshakeTimeout   = 10 * time.Second
 )
 
 var (
@@ -90,9 +104,13 @@ func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*Op
 	}
 	clientConfig := openai.DefaultConfig(apiKey)
 
-	// Set HTTP Proxy
+	// Set HTTP Proxy and sensible timeouts; the previous zero-value
+	// http.Client would hang forever on a slow or unresponsive endpoint.
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: defaultDialTimeout}).DialContext,
+		ResponseHeaderTimeout: defaultResponseHeaderTimeout,
+		TLSHandshakeTimeout:   defaultTLSHandshakeTimeout,
 	}
 	httpClient := &http.Client{
 		Transport: transport,


### PR DESCRIPTION
## Summary

Fixes #357.

`CreateClient` built the OpenAI `http.Client` with the zero-value `Timeout` and a `Transport` that only overrode `Proxy`, so a slow or unresponsive endpoint (e.g. an attacker-controlled `OPENAI_API_BASE` serving slowloris-style headers) would hang the `sgpt` process indefinitely. That's most painful in CI/CD pipelines where there is no interactive recovery path.

## Fix

Thread a custom `net.Dialer` with a 10s `Timeout` into `http.Transport`, and set:
- `ResponseHeaderTimeout: 30s`
- `TLSHandshakeTimeout: 10s`

I intentionally did **not** set a client-wide `Timeout`. `sgpt`'s `-stream` mode routes through `openai.(*Client).CreateChatCompletionStream` and keeps the connection open for long LLM responses (several minutes for large outputs is normal), so a client-wide timeout would truncate legitimate streams. `ResponseHeaderTimeout` covers the slowloris/DoS case - if the server never produces headers, the transport aborts - without penalising the common long-tail streaming path.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/api/...` (all existing tests pass)
- [x] Manually reproduced the hang by pointing `OPENAI_API_BASE` at a nc listener that accepts TCP and never sends headers; sgpt now errors out after ~30s with `net/http: timeout awaiting response headers` instead of hanging forever
