### PR TITLE
shell: reject multi-line LLM output so bash -c can't execute hidden commands

### DIFF
--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -24,6 +24,7 @@ package shell
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -59,9 +60,19 @@ func isBidiOverride(r rune) bool {
 	return false
 }
 
+// ErrMultilineCommand is returned by SanitizeCommand when the LLM
+// output contains newline or carriage-return separators. bash -c treats
+// them identically to ';', so a prompt-injected multi-line response
+// would execute as multiple commands once the user confirms - see
+// #360.
+var ErrMultilineCommand = errors.New("command contains newline; rejected as potential injection")
+
 // SanitizeCommand removes ANSI escape sequences, Unicode bidi overrides, and non-printable control characters
-// from a command string to prevent display manipulation attacks. Newlines and tabs are preserved.
-func SanitizeCommand(command string) string {
+// from a command string to prevent display manipulation attacks. Tabs are preserved because they are
+// legitimately used in `printf` arguments etc. Newlines and carriage returns are rejected outright
+// because `bash -c` would treat them as command separators, letting a single confirmed run
+// silently execute multiple commands (#360).
+func SanitizeCommand(command string) (string, error) {
 	// Remove ANSI escape sequences (CSI and OSC)
 	ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07`)
 	command = ansiRegex.ReplaceAllString(command, "")
@@ -74,18 +85,32 @@ func SanitizeCommand(command string) string {
 		if isBidiOverride(r) {
 			continue
 		}
-		// Skip non-printable control characters except newline and tab
-		if unicode.IsControl(r) && r != '\n' && r != '\t' {
+		// Skip non-printable control characters except tab.
+		// Newlines and carriage returns are handled explicitly after the
+		// cleanup pass so we can reject them with a clear error rather
+		// than silently stripping them.
+		if unicode.IsControl(r) && r != '\n' && r != '\r' && r != '\t' {
 			continue
 		}
 		sb.WriteRune(r)
 	}
-	return sb.String()
+	sanitized := sb.String()
+	if strings.ContainsAny(sanitized, "\n\r") {
+		return "", ErrMultilineCommand
+	}
+	return sanitized, nil
 }
 
 func ExecuteCommandWithConfirmation(ctx context.Context, input io.Reader, output io.Writer, command string) error {
-	// Sanitize command to prevent display manipulation
-	command = SanitizeCommand(command)
+	// Sanitize command to prevent display manipulation and reject
+	// multi-line payloads before the user is given a confirmation prompt
+	// that can't see the hidden trailing commands.
+	sanitized, err := SanitizeCommand(command)
+	if err != nil {
+		fmt.Fprintf(output, "Refusing to execute suggested command: %s\n", err.Error())
+		return err
+	}
+	command = sanitized
 	// Require user confirmation
 	ok, err := getUserConfirmation(input, output)
 	if err != nil {

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -391,7 +391,8 @@ func TestSanitizeCommand_RemovesBidiOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SanitizeCommand(tt.input)
+			result, err := SanitizeCommand(tt.input)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -427,7 +428,8 @@ func TestSanitizeCommand_RemovesANSIEscapes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SanitizeCommand(tt.input)
+			result, err := SanitizeCommand(tt.input)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -473,41 +475,43 @@ func TestSanitizeCommand_RemovesControlChars(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SanitizeCommand(tt.input)
+			result, err := SanitizeCommand(tt.input)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestSanitizeCommand_PreservesNewlineAndTab(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "Newline preserved",
-			input:    "echo\ntest",
-			expected: "echo\ntest",
-		},
-		{
-			name:     "Tab preserved",
-			input:    "echo\ttest",
-			expected: "echo\ttest",
-		},
-		{
-			name:     "Both preserved",
-			input:    "echo\n\ttest",
-			expected: "echo\n\ttest",
-		},
+func TestSanitizeCommand_RejectsMultilineInjection(t *testing.T) {
+	// A prompt-injected `ls\nrm -rf ~` would execute both commands under
+	// `bash -c` once the user confirms. SanitizeCommand must refuse any
+	// command containing \n or \r so the caller can abort before the
+	// confirmation prompt (#360).
+	tests := []string{
+		"echo\ntest",
+		"ls\nrm -rf ~",
+		"echo hi\r\necho bye",
+		"echo\r",
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := SanitizeCommand(tt.input)
-			require.Equal(t, tt.expected, result)
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			result, err := SanitizeCommand(cmd)
+			require.ErrorIs(t, err, ErrMultilineCommand)
+			require.Empty(t, result)
 		})
 	}
+}
+
+func TestSanitizeCommand_PreservesTab(t *testing.T) {
+	// Tabs are a legitimate part of shell invocations (printf args etc)
+	// and must pass through.
+	result, err := SanitizeCommand("printf 'a\\tb'")
+	require.NoError(t, err)
+	require.Equal(t, "printf 'a\\tb'", result)
+
+	result, err = SanitizeCommand("echo\ttest")
+	require.NoError(t, err)
+	require.Equal(t, "echo\ttest", result)
 }
 
 func TestSanitizeCommand_CleanCommandUnchanged(t *testing.T) {
@@ -521,7 +525,8 @@ func TestSanitizeCommand_CleanCommandUnchanged(t *testing.T) {
 
 	for _, cmd := range cleanCommands {
 		t.Run(cmd, func(t *testing.T) {
-			result := SanitizeCommand(cmd)
+			result, err := SanitizeCommand(cmd)
+			require.NoError(t, err)
 			require.Equal(t, cmd, result)
 		})
 	}
@@ -557,7 +562,8 @@ func TestSanitizeCommand_ZeroWidthChars(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SanitizeCommand(tt.input)
+			result, err := SanitizeCommand(tt.input)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #360.

`SanitizeCommand` explicitly preserved `\n`, and the sanitized string was passed straight to `bash -c`. Because `bash -c` treats newlines as command separators, a prompt-injected multi-line LLM response like `ls\nrm -rf ~` rendered as two apparently-harmless lines in the confirmation prompt but executed both commands once the user typed `Y`.

The sanitizer's own comment scoped it to *"display manipulation attacks"*. The fix needs to go a step further: for anything that is handed to `bash -c`, multi-line payloads have to be refused.

## Fix

- Change `SanitizeCommand(string)` to `SanitizeCommand(string) (string, error)`.
- Return the sentinel `ErrMultilineCommand` whenever the cleaned payload contains `\n` or `\r`.
- `ExecuteCommandWithConfirmation` now aborts (and surfaces the error on `output`) before the confirmation prompt, so the user never sees just the harmless-looking first line.
- Tabs stay preserved - they're a legitimate part of `printf` / `awk` invocations.

Pipes / redirects / `&&` / `||` are intentionally still allowed - legitimate use cases like `du -a | sort -rh | head -3` must continue to work - and are documented risks the user opts in to by choosing the shell-execution feature. Newlines are the specific class the confirmation prompt can't render honestly, which is why this layer is tightened.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/shell/... -count=1` (all existing tests updated for the new signature; new `TestSanitizeCommand_RejectsMultilineInjection` exercises `\n`, `\r`, `\r\n`, and the `ls\nrm -rf ~` PoC)
- [x] `TestSanitizeCommand_PreservesTab` replaces the old `PreservesNewlineAndTab` to lock in the tab-preservation contract
