### PR TITLE
chat: create session files with 0600 owner-only permissions

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	defaultFilePermissions = 0755
+	defaultFilePermissions = 0600
 	sessionNameMaxLength   = 65
 )
 

--- a/pkg/chat/filesystem.go
+++ b/pkg/chat/filesystem.go
@@ -161,8 +161,8 @@ func (m FilesystemChatSessionManager) SaveSession(sessionName string, messages [
 		}
 		slog.Debug("Existing session file opened and truncated")
 	} else {
-		// Create file
-		file, err = os.Create(sessionFilepath)
+		// Create file with owner-only permissions; sessions may contain sensitive data.
+		file, err = os.OpenFile(sessionFilepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, defaultFilePermissions)
 		if err != nil {
 			return err
 		}

--- a/pkg/chat/filesystem_test.go
+++ b/pkg/chat/filesystem_test.go
@@ -290,6 +290,33 @@ func createTestConfig(t *testing.T) *viper.Viper {
 	return config
 }
 
+func TestFilesystemChatSessionManager_SaveSession_FilePermissions(t *testing.T) {
+	config := createTestConfig(t)
+
+	manager, err := NewFilesystemChatSessionManager(config)
+	require.NoError(t, err)
+
+	messages := createTestMessages()
+
+	// New session: file is created via os.Create.
+	err = manager.SaveSession("perm_new", messages)
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(config.GetString("cacheDir"), "perm_new"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm(),
+		"new session file must be owner-only (0600), got %o", info.Mode().Perm())
+
+	// Existing session: file is reopened via os.OpenFile with defaultFilePermissions.
+	err = manager.SaveSession("perm_new", messages)
+	require.NoError(t, err)
+
+	info, err = os.Stat(filepath.Join(config.GetString("cacheDir"), "perm_new"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm(),
+		"reopened session file must remain owner-only (0600), got %o", info.Mode().Perm())
+}
+
 func TestFilesystemChatSessionManager_GetSession_ScannerError(t *testing.T) {
 	config := createTestConfig(t)
 


### PR DESCRIPTION
Fixes #355. Chat session files held conversation history but were created with 0644 (world-readable) via `os.Create`, and existing files were reopened with `defaultFilePermissions = 0755`; this commit changes the constant to 0600 and replaces `os.Create` with `os.OpenFile(..., O_WRONLY|O_CREATE|O_TRUNC, 0600)` so sessions are owner-only on creation and on rewrite. Added a regression test in `pkg/chat/filesystem_test.go` that asserts `info.Mode().Perm() == 0600` on both new and reopened session files.