### PR TITLE
config: validate OPENAI_API_BASE against SSRF risks

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -29,6 +29,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -117,12 +118,14 @@ func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*Op
 	}
 	clientConfig.HTTPClient = httpClient
 
-	// Check, if API base url was set
-	baseURL, isSet := os.LookupEnv("OPENAI_API_BASE")
-	if isSet {
-		// Set base url
+	// Validate OPENAI_API_BASE before applying it; an unvalidated override
+	// can redirect the Authorization header to an attacker-controlled host.
+	if baseURL, isSet := os.LookupEnv("OPENAI_API_BASE"); isSet {
+		if err := validateAPIBaseURL(baseURL); err != nil {
+			return nil, err
+		}
 		clientConfig.BaseURL = baseURL
-		slog.Debug("Setting API base url to " + baseURL)
+		slog.Warn("OPENAI_API_BASE override active", "url", baseURL)
 	}
 
 	// Build client and apply options
@@ -148,6 +151,20 @@ func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*Op
 
 	slog.Debug("OpenAI client created")
 	return client, nil
+}
+
+// validateAPIBaseURL requires an absolute https URL with a non-empty host.
+// Hostname-agnostic to preserve compatibility with Azure OpenAI, OpenRouter,
+// and self-hosted backends (Ollama, LiteLLM) fronted by TLS.
+func validateAPIBaseURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("OPENAI_API_BASE must be a valid https URL: %w", err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("OPENAI_API_BASE must be a valid https URL: %q", raw)
+	}
+	return nil
 }
 
 // CreateCompletion creates a completion for the given prompt and modifier. If chatID is provided, the chat is reused

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -65,6 +65,42 @@ func TestCreateClientMissingApiKey(t *testing.T) {
 	require.Nil(t, client)
 }
 
+func TestCreateClientAPIBaseValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{"openai", "https://api.openai.com/v1", false},
+		{"openrouter", "https://openrouter.ai/api/v1", false},
+		{"azure", "https://my-resource.openai.azure.com/openai/deployments/x", false},
+		{"localhost over https", "https://localhost:8443/v1", false},
+		{"http openai", "http://api.openai.com/v1", true},
+		{"imds via http", "http://169.254.169.254/latest/meta-data/", true},
+		{"private rfc1918 http", "http://10.0.0.1/v1", true},
+		{"empty", "", true},
+		{"missing scheme", "api.openai.com/v1", true},
+		{"file scheme", "file:///etc/passwd", true},
+		{"javascript scheme", "javascript:alert(1)", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", "test")
+			t.Setenv("OPENAI_API_BASE", tc.baseURL)
+
+			client, err := CreateClient(nil, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, client)
+				require.Contains(t, err.Error(), "OPENAI_API_BASE")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, client)
+			}
+		})
+	}
+}
+
 func TestSimplePrompt(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)


### PR DESCRIPTION
Validates OPENAI_API_BASE as an absolute https URL with a non-empty host before applying it; without this, a hostile env var or config file silently redirects the Authorization: Bearer header to an attacker-controlled endpoint. The check is hostname-agnostic to preserve compatibility with Azure OpenAI, OpenRouter, and self-hosted backends fronted by TLS.

Closes #358.