### PR TITLE
input: restrict --input file reads to the working directory

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -317,16 +317,25 @@ func (c *OpenAIClient) createPromptMessages(prompts, input []string) (messages [
 }
 
 func (c *OpenAIClient) buildImageFileData(inputFile string) (imageData string, err error) {
+	// Reject paths outside the working directory so --input cannot
+	// exfiltrate arbitrary files (e.g. /etc/passwd, ~/.ssh/id_rsa)
+	// to the OpenAI API.
+	var resolved string
+	resolved, err = fs.ResolveUnderCwd(inputFile)
+	if err != nil {
+		return
+	}
+
 	// Get image filetype
 	var filetype string
-	filetype, err = fs.GetImageFileType(inputFile)
+	filetype, err = fs.GetImageFileType(resolved)
 	if err != nil {
 		return
 	}
 
 	// Load image from file
 	var b64Image string
-	b64Image, err = fs.LoadBase64ImageFromFile(inputFile)
+	b64Image, err = fs.LoadBase64ImageFromFile(resolved)
 	if err != nil {
 		return
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -40,6 +41,34 @@ const (
 
 // ErrInputTooLarge is returned by ReadAll when the input exceeds maxInputSize.
 var ErrInputTooLarge = errors.New("input exceeds 1 MiB limit")
+
+// ErrPathOutsideCwd is returned by ResolveUnderCwd when the input path
+// resolves to a location outside the current working directory.
+var ErrPathOutsideCwd = errors.New("path is outside the working directory")
+
+// ErrNotImage is returned by GetImageFileType when the sniffed content
+// type does not begin with "image/".
+var ErrNotImage = errors.New("file is not an image")
+
+// ResolveUnderCwd resolves p to an absolute path and rejects it if it
+// escapes the current working directory. It is used to prevent --input
+// from reading arbitrary files outside the working directory and
+// transmitting their contents to the OpenAI API.
+func ResolveUnderCwd(p string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q", ErrPathOutsideCwd, p)
+	}
+	return abs, nil
+}
 
 const (
 	defaultDirPermissions = 0755
@@ -132,6 +161,10 @@ func GetImageFileType(inputFile string) (string, error) {
 
 	// Always returns a valid content-type and "application/octet-stream" if no others seemed to match.
 	contentType := http.DetectContentType(buffer)
+
+	if !strings.HasPrefix(contentType, "image/") {
+		return "", fmt.Errorf("%w: %s detected for %q", ErrNotImage, contentType, inputFile)
+	}
 
 	return contentType, nil
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -23,6 +23,7 @@ package fs
 
 import (
 	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -187,4 +188,48 @@ func TestReadAll_LimitExceeded(t *testing.T) {
 	large := strings.NewReader(strings.Repeat("a", maxInputSize+1))
 	_, err := ReadAll(large)
 	require.ErrorIs(t, err, ErrInputTooLarge)
+}
+
+func TestResolveUnderCwd_AcceptsFileInCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target := filepath.Join(dir, "image.png")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0o600))
+
+	got, err := ResolveUnderCwd("image.png")
+	require.NoError(t, err)
+	require.Equal(t, target, got)
+}
+
+func TestResolveUnderCwd_RejectsAbsolutePathOutsideCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	outside := "/etc/passwd"
+	if runtime.GOOS == "windows" {
+		outside = `C:\Windows\System32\drivers\etc\hosts`
+	}
+
+	_, err := ResolveUnderCwd(outside)
+	require.ErrorIs(t, err, ErrPathOutsideCwd)
+}
+
+func TestResolveUnderCwd_RejectsRelativeTraversal(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "child")
+	require.NoError(t, os.Mkdir(child, 0o755))
+	t.Chdir(child)
+
+	_, err := ResolveUnderCwd("../escape.txt")
+	require.ErrorIs(t, err, ErrPathOutsideCwd)
+}
+
+func TestGetImageFileType_RejectsNonImage(t *testing.T) {
+	dir := t.TempDir()
+	notImage := filepath.Join(dir, "passwd")
+	require.NoError(t, os.WriteFile(notImage, []byte("root:x:0:0:root:/root:/bin/bash\n"), 0o600))
+
+	_, err := GetImageFileType(notImage)
+	require.ErrorIs(t, err, ErrNotImage)
 }


### PR DESCRIPTION
Resolves #359. `--input <path>` now refuses paths outside the current working directory and rejects files whose detected content type is not `image/*`, so a user can't be tricked into uploading `/etc/passwd` or `~/.ssh/id_rsa` to the OpenAI vision API. Tests cover the in-CWD success path and absolute / `..`-traversal / non-image rejection paths.