### PR TITLE
fix(config): allow http OPENAI_API_BASE for loopback and RFC1918

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ visit [shell-gpt](https://github.com/TheR1D/shell_gpt). Please keep this in mind
   - [GPT-4o and GPT-4 Vision API Support](#gpt-4o-and-gpt-4-vision-api-support)
   - [o1 API Support](#o1-api-support)
   - [OpenRouter API Support](#openrouter-api-support)
+  - [Local LLM Support](#local-llm-support)
   - [Chat Capabilities](#chat-capabilities)
   - [Generating and Executing Shell Commands](#generating-and-executing-shell-commands)
   - [Interactive Shell Sessions](#interactive-shell-sessions)
@@ -300,6 +301,30 @@ Browse the complete list of available models on the [OpenRouter models page](htt
 > Under [Integrations](https://openrouter.ai/settings/integrations) in your OpenRouter account, you can link your
 > existing OpenAI API key. This allows you to use any remaining OpenAI credits when accessing OpenAI models through
 > OpenRouter.
+
+### Local LLM Support
+
+SGPT works with any OpenAI-compatible local LLM backend (Ollama, LiteLLM, vLLM, llama.cpp, etc.) by pointing
+`OPENAI_API_BASE` at the backend's URL. For local setups, plain `http://` is permitted for loopback and private
+network ranges:
+
+```shell
+export OPENAI_API_KEY="dummy"  # most local backends ignore the key but the env var must be set
+export OPENAI_API_BASE="http://localhost:11434/v1"  # e.g. Ollama
+sgpt -m "llama3" "mass of sun"
+```
+
+LAN hostnames that aren't IP literals (e.g. `http://thinkbox:8080/v1`) need an explicit opt-out because they can't
+be classified as private without DNS resolution. Pass the flag on the command line, or set the key in your config
+file:
+
+```shell
+sgpt --insecure-api-base "..."
+# or set `insecureAPIBase: true` in ~/.config/sgpt/config.yaml
+```
+
+See [Query Models — Override OpenAI API base URL](docs/usage/query-models.md#override-openai-api-base-url) for the
+full validation rules and the rationale.
 
 ### Chat Capabilities
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,12 @@ maxTokens: 2048
 model: "gpt-4"
 temperature: "1"
 topP: "1"
+insecureAPIBase: false
 ```
 
 These options override the default values for the corresponding command line options.
+
+Set `insecureAPIBase: true` to skip validation of `OPENAI_API_BASE`. Required
+for local LLM setups that point at a single-label LAN hostname (e.g.
+`http://thinkbox:8080/v1`); see [Query Models](usage/query-models.md#opt-out-for-lan-hostnames)
+for the validation rules.

--- a/docs/usage/query-models.md
+++ b/docs/usage/query-models.md
@@ -72,3 +72,39 @@ You can override the OpenAI base URL by setting the `OPENAI_API_BASE` environmen
 ```shell
 export OPENAI_API_BASE=https://api.openai.com/v1
 ```
+
+### Validation rules
+
+To prevent an attacker-set environment variable from silently redirecting your
+API key to a hostile endpoint, the value is validated before use:
+
+- `https://<any-host>` — always allowed.
+- `http://localhost`, `http://127.x.x.x`, `http://[::1]` — allowed (loopback).
+- `http://10.x.x.x`, `http://172.16-31.x.x`, `http://192.168.x.x`,
+  `http://[fd00::/8]` — allowed (RFC1918 + RFC4193 ULA).
+- Everything else over plain `http://` is rejected, including link-local
+  addresses such as `http://169.254.169.254/` (cloud instance metadata).
+
+### Opt-out for LAN hostnames
+
+Setups that point at a single-label hostname like `http://thinkbox:8080/v1`
+can't be classified by IP literal and must opt out of validation explicitly.
+Either of the following enables the opt-out (the flag takes precedence over
+the config file):
+
+```shell
+# 1. CLI flag
+sgpt --insecure-api-base "..."
+
+# 2. Config file (~/.config/sgpt/config.yaml)
+insecureAPIBase: true
+```
+
+There is deliberately no environment-variable form of this opt-out: the
+[`OPENAI_API_BASE` SSRF report](https://github.com/tbckr/sgpt/issues/358) that
+introduced this validation assumes an attacker who controls the environment,
+and an env-var opt-out would undo that protection. The flag and config file
+both require either CLI access or write access to your config directory.
+
+When the opt-out is active, a warning is logged once per invocation so you know
+validation was skipped.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -120,12 +120,22 @@ func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*Op
 
 	// Validate OPENAI_API_BASE before applying it; an unvalidated override
 	// can redirect the Authorization header to an attacker-controlled host.
+	// The insecureAPIBase opt-out lets users with single-label LAN hostnames
+	// (e.g. http://thinkbox:8080/v1) bypass validation entirely.
+	allowInsecure := false
+	if config != nil {
+		allowInsecure = config.GetBool("insecureAPIBase")
+	}
 	if baseURL, isSet := os.LookupEnv("OPENAI_API_BASE"); isSet {
-		if err := validateAPIBaseURL(baseURL); err != nil {
+		if err := validateAPIBaseURL(baseURL, allowInsecure); err != nil {
 			return nil, err
 		}
 		clientConfig.BaseURL = baseURL
-		slog.Warn("OPENAI_API_BASE override active", "url", baseURL)
+		if allowInsecure {
+			slog.Warn("OPENAI_API_BASE validation skipped via insecure-api-base", "url", baseURL)
+		} else {
+			slog.Debug("OPENAI_API_BASE override active", "url", baseURL)
+		}
 	}
 
 	// Build client and apply options
@@ -153,18 +163,53 @@ func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*Op
 	return client, nil
 }
 
-// validateAPIBaseURL requires an absolute https URL with a non-empty host.
-// Hostname-agnostic to preserve compatibility with Azure OpenAI, OpenRouter,
-// and self-hosted backends (Ollama, LiteLLM) fronted by TLS.
-func validateAPIBaseURL(raw string) error {
+// validateAPIBaseURL accepts https for any host, and http only for loopback
+// (localhost, 127.0.0.0/8, ::1) or private addresses (RFC1918 + RFC4193 ULA).
+// This blocks the cloud IMDS attack vector (169.254.0.0/16 is link-local, not
+// private) while permitting the dominant local-LLM pattern of plain-http
+// containers on the same host. When allowInsecure is true, the check is
+// skipped entirely so users with single-label LAN hostnames (e.g.
+// http://thinkbox:8080/v1) that can't be classified by IP literal can opt out.
+//
+// Note: 100.64.0.0/10 (CGNAT, RFC6598) is intentionally NOT in the allow-list
+// because IsPrivate() does not cover it; cloud and Tailscale environments use
+// this range for infrastructure that we don't want to silently route to.
+func validateAPIBaseURL(raw string, allowInsecure bool) error {
+	if allowInsecure {
+		return nil
+	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return fmt.Errorf("OPENAI_API_BASE must be a valid https URL: %w", err)
+		return fmt.Errorf("OPENAI_API_BASE must be a valid URL: %w", err)
 	}
-	if u.Scheme != "https" || u.Host == "" {
-		return fmt.Errorf("OPENAI_API_BASE must be a valid https URL: %q", raw)
+	if u.Host == "" {
+		return fmt.Errorf("OPENAI_API_BASE must include a host: %q", raw)
 	}
-	return nil
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" {
+			return nil
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("OPENAI_API_BASE: http only allowed for loopback or RFC1918/ULA hosts; use https or set insecureAPIBase=true (--insecure-api-base or insecureAPIBase: true in config.yaml) to override: %q", raw)
+		}
+		// Explicitly reject link-local (IPv4 169.254/16 — cloud IMDS;
+		// IPv6 fe80::/10 — cross-VM same-segment exfiltration) and the
+		// IPv4 unspecified range (0.0.0.0/8 — routes ambiguously).
+		if ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+			return fmt.Errorf("OPENAI_API_BASE: http to link-local or unspecified addresses is not allowed: %q", raw)
+		}
+		if ip.IsLoopback() || ip.IsPrivate() {
+			return nil
+		}
+		return fmt.Errorf("OPENAI_API_BASE: http only allowed for loopback or RFC1918/ULA hosts; use https or set insecureAPIBase=true (--insecure-api-base or insecureAPIBase: true in config.yaml) to override: %q", raw)
+	default:
+		return fmt.Errorf("OPENAI_API_BASE scheme must be http or https: %q", raw)
+	}
 }
 
 // CreateCompletion creates a completion for the given prompt and modifier. If chatID is provided, the chat is reused

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/sashabaranov/go-openai"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/tbckr/sgpt/v2/internal/testlib"
 	"github.com/tbckr/sgpt/v2/pkg/chat"
@@ -71,13 +72,38 @@ func TestCreateClientAPIBaseValidation(t *testing.T) {
 		baseURL string
 		wantErr bool
 	}{
+		// https is always allowed
 		{"openai", "https://api.openai.com/v1", false},
 		{"openrouter", "https://openrouter.ai/api/v1", false},
 		{"azure", "https://my-resource.openai.azure.com/openai/deployments/x", false},
 		{"localhost over https", "https://localhost:8443/v1", false},
+
+		// http allowed for loopback and private ranges (local LLM containers)
+		{"http localhost", "http://localhost:8080/v1", false},
+		{"http loopback ipv4", "http://127.0.0.1:11434/v1", false},
+		{"http loopback ipv6", "http://[::1]:8080/v1", false},
+		{"http rfc1918 10", "http://10.0.0.5/v1", false},
+		{"http rfc1918 172.16", "http://172.16.0.1/v1", false},
+		{"http rfc1918 192.168", "http://192.168.1.10:8080/v1", false},
+		{"http ipv6 ula", "http://[fd00::1]/v1", false},
+
+		// http rejected for public hosts and IMDS
 		{"http openai", "http://api.openai.com/v1", true},
+		{"http public ipv4", "http://1.2.3.4/v1", true},
 		{"imds via http", "http://169.254.169.254/latest/meta-data/", true},
-		{"private rfc1918 http", "http://10.0.0.1/v1", true},
+		{"http single-label hostname", "http://thinkbox:8080/v1", true},
+
+		// explicit link-local / unspecified rejections
+		{"http ipv6 link-local", "http://[fe80::1]/v1", true},
+		{"http ipv4 unspecified", "http://0.0.0.0:11434/v1", true},
+		{"http ipv4 zero-prefix", "http://0.1.2.3/v1", true},
+		{"http cgnat", "http://100.64.0.1/v1", true},
+		// IPv4-mapped IPv6 of IMDS — Go's IsLinkLocalUnicast classifies it correctly
+		{"http ipv4-mapped imds", "http://[::ffff:169.254.169.254]/", true},
+		// userinfo trick: localhost in userinfo, evil.com as host
+		{"http userinfo trick", "http://localhost@evil.com/", true},
+
+		// malformed / non-network schemes
 		{"empty", "", true},
 		{"missing scheme", "api.openai.com/v1", true},
 		{"file scheme", "file:///etc/passwd", true},
@@ -99,6 +125,20 @@ func TestCreateClientAPIBaseValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateClientAPIBaseInsecureOptOut(t *testing.T) {
+	// insecureAPIBase=true bypasses validation entirely so single-label LAN
+	// hostnames work (the reporter's http://thinkbox:8080/v1 case in #371).
+	t.Setenv("OPENAI_API_KEY", "test")
+	t.Setenv("OPENAI_API_BASE", "http://thinkbox:8080/v1")
+
+	v := viper.New()
+	v.Set("insecureAPIBase", true)
+
+	client, err := CreateClient(v, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 }
 
 func TestSimplePrompt(t *testing.T) {

--- a/pkg/cli/check_test.go
+++ b/pkg/cli/check_test.go
@@ -61,3 +61,25 @@ func TestCheckCmdUnsetEnvAPIKey(t *testing.T) {
 	}).Execute([]string{"check"})
 	require.Equal(t, 1, mem.code)
 }
+
+func TestCheckCmdInsecureAPIBaseFlag(t *testing.T) {
+	// Exercise the full --insecure-api-base flag path: cobra parses, viper
+	// reads, and CreateClient skips validation for a single-label LAN host.
+	testCtx := testlib.NewTestCtx(t)
+	testlib.SetAPIKey(t)
+	t.Setenv("OPENAI_API_BASE", "http://thinkbox:8080/v1")
+
+	// Without the flag, validation rejects the URL.
+	memFail := &exitMemento{}
+	newRootCmd(memFail.Exit, testCtx.Config, mockIsPipedShell(false, nil), func(v *viper.Viper, w io.Writer) (api.Completer, error) {
+		return api.CreateClient(v, w)
+	}).Execute([]string{"check"})
+	require.Equal(t, 1, memFail.code)
+
+	// With the flag, validation is skipped and the client builds.
+	memOK := &exitMemento{}
+	newRootCmd(memOK.Exit, testlib.NewTestCtx(t).Config, mockIsPipedShell(false, nil), func(v *viper.Viper, w io.Writer) (api.Completer, error) {
+		return api.CreateClient(v, w)
+	}).Execute([]string{"--insecure-api-base", "check"})
+	require.Equal(t, 0, memOK.code)
+}

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -51,8 +51,8 @@ func TestConfigCmdInit(t *testing.T) {
 	// config must only contain values for model, maxtokens, temperature, topp
 	require.NoError(t, testCtx.Config.ReadInConfig())
 	// TESTING may be in the config, because this is a test
-	require.Equal(t, 8, len(testCtx.Config.AllSettings()))
-	for _, key := range []string{"model", "maxtokens", "temperature", "topp", "cachedir", "personas", "stream", "testing"} {
+	require.Equal(t, 9, len(testCtx.Config.AllSettings()))
+	for _, key := range []string{"model", "maxtokens", "temperature", "topp", "cachedir", "personas", "stream", "insecureapibase", "testing"} {
 		require.Contains(t, testCtx.Config.AllSettings(), key)
 	}
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -306,6 +306,21 @@ $ echo "lang: Python" | sgpt code --template "Write a hello world program in {{ 
 	cmd.PersistentFlags().BoolVarP(&root.verbose, "verbose", "v", false,
 		"enable more verbose output for debugging")
 
+	// insecure-api-base persistent flag — opt-out for OPENAI_API_BASE validation,
+	// needed for LAN hostnames (single-label, mDNS) that can't be classified by
+	// IP literal. Deliberately NOT bound to an env var: the #358 threat model
+	// assumes attacker control of environment, and an env-var opt-out would
+	// undo the validation guarantee. The flag plus a config-file key
+	// (insecureAPIBase) are intentional opt-ins that require either CLI access
+	// or write access to ~/.config/sgpt/, both of which are stronger trust
+	// signals than env var manipulation.
+	cmd.PersistentFlags().Bool("insecure-api-base", false,
+		"skip OPENAI_API_BASE validation (allows arbitrary http:// hosts)")
+	if err := config.BindPFlag("insecureAPIBase", cmd.PersistentFlags().Lookup("insecure-api-base")); err != nil {
+		slog.Error("Failed to bind insecure-api-base flag to viper", "error", err)
+		panic("Failed to bind insecure-api-base flag to viper")
+	}
+
 	cmd.AddCommand(
 		newChatCmd(config).cmd,
 		newCheckCmd(config, createClientFn).cmd,
@@ -407,6 +422,8 @@ func setViperDefaults(config *viper.Viper) error {
 	config.SetDefault("topP", 1)
 	// stream
 	config.SetDefault("stream", false)
+	// insecure-api-base
+	config.SetDefault("insecureAPIBase", false)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Restores local LLM compatibility broken by #367: `OPENAI_API_BASE=http://localhost:11434/v1` (Ollama / LiteLLM / vLLM and friends) is allowed again. The `https`-only validation now accepts `http` for loopback (`localhost`, `127.0.0.0/8`, `::1`), RFC1918 (`10/8`, `172.16/12`, `192.168/16`) and RFC4193 ULA (`fc00::/7`).
- Link-local (`169.254/16` IMDS, `fe80::/10`) and `0.0.0.0/8` are rejected explicitly so the SSRF / key-exfiltration vector from #358 stays blocked.
- Adds an `--insecure-api-base` persistent flag (and `insecureAPIBase` config-file key) for single-label LAN hostnames like `http://thinkbox:8080/v1` that can't be classified by IP literal. Deliberately **not** bound to an env var — #358's threat model assumes attacker control of the environment, so an env-var opt-out would undo the validation guarantee.
- Demotes the per-request `slog.Warn("OPENAI_API_BASE override active", ...)` (added in #367) back to `slog.Debug`; only the opt-out path still emits a one-shot WARN. Scripts that capture stderr (`2>&1`) are quiet again.

Closes #371.

## Test plan

- [x] `go test ./...` (extended `TestCreateClientAPIBaseValidation` table with loopback/RFC1918/ULA/IMDS/IPv4-mapped/link-local/unspecified/CGNAT/userinfo-trick cases; new `TestCreateClientAPIBaseInsecureOptOut` covers the viper opt-out)
- [x] `TestCheckCmdInsecureAPIBaseFlag` exercises the `--insecure-api-base` flag end-to-end through cobra → viper → `CreateClient`
- [x] `golangci-lint run ./...` (0 issues with golangci-lint 2.12.2 / go1.26.2 via the updated flake)
- [x] Manual smoke: `OPENAI_API_BASE=http://localhost:11434/v1 sgpt "hi"` — no warning, validation passes
- [x] Manual smoke: `OPENAI_API_BASE=http://thinkbox:8080/v1 sgpt "hi"` — fails with discoverable error pointing to `--insecure-api-base` / `insecureAPIBase: true`
- [x] Manual smoke: `OPENAI_API_BASE=http://169.254.169.254/ sgpt "hi"` — still blocked (link-local explicitly rejected)