### PR TITLE
fix: address security issues in chat rm, --input path containment, and image size

### DIFF
--- a/pkg/chat/filesystem.go
+++ b/pkg/chat/filesystem.go
@@ -202,6 +202,11 @@ func (m FilesystemChatSessionManager) ListSessions() ([]string, error) {
 }
 
 func (m FilesystemChatSessionManager) DeleteSession(sessionName string) error {
+	// Validate session name
+	if err := validateSessionName(sessionName); err != nil {
+		return err
+	}
+
 	sessionFilepath, err := m.getFilepathForSession(sessionName)
 	slog.Debug("Deleting session file at: " + sessionFilepath)
 	if err != nil {

--- a/pkg/chat/filesystem_test.go
+++ b/pkg/chat/filesystem_test.go
@@ -263,6 +263,25 @@ func TestFilesystemChatSessionManager_DeleteNotExistingSession(t *testing.T) {
 	require.False(t, exists)
 }
 
+func TestFilesystemChatSessionManager_DeleteSession_PathTraversal(t *testing.T) {
+	config := createTestConfig(t)
+	cacheDir := config.GetString("cacheDir")
+
+	// Sentinel file living outside the cache directory - a traversal payload
+	// would need to escape cacheDir to reach it.
+	outsideDir := filepath.Dir(cacheDir)
+	sentinel := filepath.Join(outsideDir, "sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("do not delete"), 0o600))
+
+	manager, err := NewFilesystemChatSessionManager(config)
+	require.NoError(t, err)
+
+	traversal := ".." + string(filepath.Separator) + filepath.Base(sentinel)
+	err = manager.DeleteSession(traversal)
+	require.ErrorIs(t, err, ErrChatSessionNameInvalid)
+	require.FileExists(t, sentinel)
+}
+
 func createTestMessages() []openai.ChatCompletionMessage {
 	return []openai.ChatCompletionMessage{
 		{

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -87,10 +87,11 @@ func ResolveUnderCwd(p string) (string, error) {
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("%w: %q", ErrPathOutsideCwd, p)
 	}
-	// Return the lexical (non-symlink-resolved) path so callers open the
-	// file the user actually named; the symlink resolution above is only
-	// used to decide containment.
-	return abs, nil
+	// Return the symlink-resolved path, not the lexical one: callers must
+	// open the same path that was just checked for containment, otherwise
+	// a symlink swapped in between this check and the caller's os.Open
+	// would let the open silently escape cwd again (TOCTOU).
+	return realAbs, nil
 }
 
 // resolveSymlinksBestEffort resolves symlinks in p. If p does not exist

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -37,10 +37,17 @@ import (
 const (
 	// maxInputSize is the upper limit for ReadAll (1 MiB).
 	maxInputSize = 1 << 20
+	// maxImageSize is the upper limit for LoadBase64ImageFromFile (20 MiB),
+	// matching the OpenAI vision API's per-image limit.
+	maxImageSize = 20 << 20
 )
 
 // ErrInputTooLarge is returned by ReadAll when the input exceeds maxInputSize.
 var ErrInputTooLarge = errors.New("input exceeds 1 MiB limit")
+
+// ErrImageTooLarge is returned by LoadBase64ImageFromFile when the image
+// exceeds maxImageSize.
+var ErrImageTooLarge = errors.New("image exceeds 20 MiB limit")
 
 // ErrPathOutsideCwd is returned by ResolveUnderCwd when the input path
 // resolves to a location outside the current working directory.
@@ -215,13 +222,25 @@ func GetImageFileType(inputFile string) (string, error) {
 	return contentType, nil
 }
 
-// LoadBase64ImageFromFile loads a base64 encoded image from a file
+// LoadBase64ImageFromFile loads a base64 encoded image from a file.
+// Returns ErrImageTooLarge if the file exceeds maxImageSize.
 func LoadBase64ImageFromFile(inputFile string) (string, error) {
-	// Load image from file
-	imageBytes, err := os.ReadFile(inputFile)
+	file, err := os.Open(inputFile)
 	if err != nil {
 		return "", err
 	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	imageBytes, err := io.ReadAll(io.LimitReader(file, maxImageSize+1))
+	if err != nil {
+		return "", fmt.Errorf("read image: %w", err)
+	}
+	if len(imageBytes) > maxImageSize {
+		return "", ErrImageTooLarge
+	}
+
 	// Convert image to base64
 	b64Image := base64.StdEncoding.EncodeToString(imageBytes)
 	return b64Image, nil

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -54,20 +54,61 @@ var ErrNotImage = errors.New("file is not an image")
 // escapes the current working directory. It is used to prevent --input
 // from reading arbitrary files outside the working directory and
 // transmitting their contents to the OpenAI API.
+//
+// The containment check is performed on the symlink-resolved form of both
+// the working directory and p, so a symlink placed inside the working
+// directory that targets a location outside it is rejected rather than
+// silently followed.
 func ResolveUnderCwd(p string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get working directory: %w", err)
 	}
+	realCwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
 	abs, err := filepath.Abs(p)
 	if err != nil {
 		return "", fmt.Errorf("resolve path: %w", err)
 	}
-	rel, err := filepath.Rel(cwd, abs)
+	realAbs, err := resolveSymlinksBestEffort(abs)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	rel, err := filepath.Rel(realCwd, realAbs)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("%w: %q", ErrPathOutsideCwd, p)
 	}
+	// Return the lexical (non-symlink-resolved) path so callers open the
+	// file the user actually named; the symlink resolution above is only
+	// used to decide containment.
 	return abs, nil
+}
+
+// resolveSymlinksBestEffort resolves symlinks in p. If p does not exist
+// yet, it walks up to the nearest existing ancestor, resolves that, and
+// re-appends the unresolved remainder - this lets ResolveUnderCwd check
+// containment for paths that will be created later while still catching
+// symlinks that point outside the working directory.
+func resolveSymlinksBestEffort(p string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	parent := filepath.Dir(p)
+	if parent == p {
+		// Reached the root without finding an existing ancestor.
+		return p, nil
+	}
+	resolvedParent, err := resolveSymlinksBestEffort(parent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedParent, filepath.Base(p)), nil
 }
 
 const (

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -212,6 +212,27 @@ func TestResolveUnderCwd_AcceptsFileInCwd(t *testing.T) {
 	require.Equal(t, target, got)
 }
 
+func TestResolveUnderCwd_RejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	outsideDir := t.TempDir()
+	secret := filepath.Join(outsideDir, "id_rsa")
+	require.NoError(t, os.WriteFile(secret, []byte("private key"), 0o600))
+
+	// Symlink lives inside cwd but points outside it - the lexical check
+	// alone would accept this.
+	link := filepath.Join(dir, "photo.png")
+	require.NoError(t, os.Symlink(secret, link))
+
+	_, err := ResolveUnderCwd("photo.png")
+	require.ErrorIs(t, err, ErrPathOutsideCwd)
+}
+
 func TestResolveUnderCwd_RejectsAbsolutePathOutsideCwd(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -139,6 +139,20 @@ func TestLoadBase64ImageFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadBase64ImageFromFile_LimitExceeded(t *testing.T) {
+	dir := t.TempDir()
+	large := filepath.Join(dir, "large.png")
+
+	f, err := os.Create(large)
+	require.NoError(t, err)
+	// Write one byte more than maxImageSize without holding it all in memory.
+	require.NoError(t, f.Truncate(maxImageSize+1))
+	require.NoError(t, f.Close())
+
+	_, err = LoadBase64ImageFromFile(large)
+	require.ErrorIs(t, err, ErrImageTooLarge)
+}
+
 func TestGetImageFileType(t *testing.T) {
 	type args struct {
 		inputFile string

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -22,6 +22,7 @@
 package fs
 
 import (
+	"encoding/base64"
 	"io"
 	"os"
 	"path/filepath"
@@ -153,6 +154,23 @@ func TestLoadBase64ImageFromFile_LimitExceeded(t *testing.T) {
 	require.ErrorIs(t, err, ErrImageTooLarge)
 }
 
+func TestLoadBase64ImageFromFile_ExactlyAtLimit(t *testing.T) {
+	dir := t.TempDir()
+	atLimit := filepath.Join(dir, "at-limit.png")
+
+	f, err := os.Create(atLimit)
+	require.NoError(t, err)
+	// A file of exactly maxImageSize bytes must be accepted - only strictly
+	// larger files should trip ErrImageTooLarge.
+	require.NoError(t, f.Truncate(maxImageSize))
+	require.NoError(t, f.Close())
+
+	got, err := LoadBase64ImageFromFile(atLimit)
+	require.NoError(t, err)
+	// base64 encodes 3 bytes as 4 characters (with padding for the remainder).
+	require.Equal(t, base64.StdEncoding.EncodedLen(maxImageSize), len(got))
+}
+
 func TestGetImageFileType(t *testing.T) {
 	type args struct {
 		inputFile string
@@ -221,9 +239,17 @@ func TestResolveUnderCwd_AcceptsFileInCwd(t *testing.T) {
 	target := filepath.Join(dir, "image.png")
 	require.NoError(t, os.WriteFile(target, []byte("data"), 0o600))
 
+	// ResolveUnderCwd returns the symlink-resolved path (see
+	// TestResolveUnderCwd_AcceptsSymlinkWithinCwd for why), so compare
+	// against the resolved form rather than the lexical one - on platforms
+	// where the temp dir itself sits behind a symlink (e.g. macOS) they
+	// would otherwise differ even though no symlink escape occurred.
+	realTarget, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+
 	got, err := ResolveUnderCwd("image.png")
 	require.NoError(t, err)
-	require.Equal(t, target, got)
+	require.Equal(t, realTarget, got)
 }
 
 func TestResolveUnderCwd_RejectsSymlinkEscape(t *testing.T) {
@@ -244,6 +270,67 @@ func TestResolveUnderCwd_RejectsSymlinkEscape(t *testing.T) {
 	require.NoError(t, os.Symlink(secret, link))
 
 	_, err := ResolveUnderCwd("photo.png")
+	require.ErrorIs(t, err, ErrPathOutsideCwd)
+}
+
+func TestResolveUnderCwd_AcceptsSymlinkWithinCwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target := filepath.Join(dir, "actual.png")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0o600))
+
+	// The symlink and its target both live inside cwd, so this must be
+	// accepted - the containment fix must not reject every symlink
+	// wholesale, only ones that escape the working directory.
+	link := filepath.Join(dir, "link.png")
+	require.NoError(t, os.Symlink(target, link))
+
+	realTarget, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+
+	got, err := ResolveUnderCwd("link.png")
+	require.NoError(t, err)
+	require.Equal(t, realTarget, got)
+}
+
+func TestResolveUnderCwd_AcceptsNonExistentFileInCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	realDir, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	// "not-created-yet.png" does not exist, so ResolveUnderCwd must fall
+	// back to resolving the nearest existing ancestor (cwd itself) via
+	// resolveSymlinksBestEffort rather than failing outright.
+	got, err := ResolveUnderCwd("not-created-yet.png")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(realDir, "not-created-yet.png"), got)
+}
+
+func TestResolveUnderCwd_RejectsNonExistentFileBehindSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	outsideDir := t.TempDir()
+
+	// The symlinked directory itself exists and lives inside cwd, but the
+	// file underneath it does not exist yet - this exercises the recursive
+	// branch of resolveSymlinksBestEffort walking up to an existing
+	// ancestor that turns out to be a symlink escaping cwd.
+	link := filepath.Join(dir, "outside-link")
+	require.NoError(t, os.Symlink(outsideDir, link))
+
+	_, err := ResolveUnderCwd(filepath.Join("outside-link", "not-created-yet.png"))
 	require.ErrorIs(t, err, ErrPathOutsideCwd)
 }
 


### PR DESCRIPTION
## Summary

Fixes the three open `security`-tagged issues:

- **#375** — `DeleteSession` skipped `validateSessionName`, so `sgpt chat rm "../../../../home/user/.bashrc"` could delete arbitrary files. Now validates the session name like every other session method.
- **#376** — `ResolveUnderCwd` only checked path containment lexically, so a symlink inside the working directory pointing outside it (e.g. `ln -s ~/.ssh/id_rsa ./photo.png`) bypassed the `--input` containment guard. Now resolves symlinks on both sides of the comparison before the containment check.
- **#378** — `LoadBase64ImageFromFile` read `--input` files with no size limit, unlike the 1 MiB-capped stdin readers. Now caps reads at 20 MiB (OpenAI's vision per-image limit) and returns `ErrImageTooLarge` when exceeded.

Closes #375
Closes #376
Closes #378

## Test plan

- [x] `go test ./... -timeout=5m` — all packages pass except a pre-existing, unrelated Windows file-permission test (`TestFilesystemChatSessionManager_SaveSession_FilePermissions`, fails identically on `main` since Windows doesn't honor Unix `0600` mode bits)
- [x] New regression tests added:
  - `TestFilesystemChatSessionManager_DeleteSession_PathTraversal`
  - `TestResolveUnderCwd_RejectsSymlinkEscape` (skipped on Windows — symlink creation needs elevated privileges there)
  - `TestLoadBase64ImageFromFile_LimitExceeded`
- [x] `golangci-lint run --timeout=5m -c .golangci.yaml` — no new issues (gosec, revive, staticcheck all clean on changed code)