### PR TITLE
ci: pin goreleaser check to v2.15.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,11 @@ jobs:
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
-          version: latest
+          # Pinned to the last v2.15.x release: goreleaser v2.16.0 makes `check` fail
+          # on the deprecated `dockers`/`docker_manifests`/`brews` blocks still used in
+          # .goreleaser.yaml. Unpin once migrated to `dockers_v2` + `homebrew_casks`.
+          # See https://goreleaser.com/deprecations
+          version: "v2.15.4"
           args: check
       - run: ./sgpt version
 


### PR DESCRIPTION
## Problem

The CI Pipeline has been **red on `main` since 2026-06-03** (last green: 2026-05-22). The failing step is `goreleaser check` — not a Go test.

GoReleaser **v2.16.0** (released 2026-05-24) changed `goreleaser check` to exit non-zero when the config uses **deprecated** properties. `.goreleaser.yaml` still uses:

- `dockers` / `docker_manifests` → deprecated in favor of `dockers_v2`
- `brews` → deprecated in favor of `homebrew_casks`

Because CI pinned goreleaser to `version: latest`, it rolled onto v2.16.0 and the check step started failing. The Go 1.26.5 commit was just the latest trigger.

```
• .goreleaser.yaml   error=configuration is valid, but uses deprecated properties
⨯ check failed       error=1 out of 1 configuration file(s) have issues
```

## Fix

Pin the `check` step to **v2.15.4** — the last release that reports these as warnings instead of errors. Verified locally: `v2.15.4 check` exits `0` on the current config.

- `release.yml` intentionally stays on `latest`: `goreleaser release` only *warns* on deprecations (they still function), so real releases keep working. Release path untouched.
- `.goreleaser.yaml` and the `homebrew-tap` repo are unchanged.

## Renovate

No exclusion needed. The `github-actions` manager only bumps the `uses:` digest, and the `regexManagers:githubActionsVersions` preset only tracks `version:` fields carrying a `# renovate:` annotation — which this pin deliberately omits. So the pin stays put until changed by hand (important, since the shared preset automerges minor/patch with `ignoreTests: true`).

## Deferred debt

The deprecated blocks will eventually be **removed** upstream, which would break the actual release. Migration TODO (tracked via the code comment on the pin):

- `dockers` / `docker_manifests` → `dockers_v2` (+ `Dockerfile.goreleaser` update)
- `brews` → `homebrew_casks` (+ `tap_migrations.json` and removing the old formula in `tbckr/homebrew-tap`)

Once migrated, unpin back to `latest`.