### PR TITLE
feat(api): support api_key and base_url in config.yaml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,11 +13,24 @@ model: "gpt-4"
 temperature: "1"
 topP: "1"
 insecureAPIBase: false
+api_key: "sk-..."
+base_url: "https://api.openai.com/v1"
 ```
 
 These options override the default values for the corresponding command line options.
 
-Set `insecureAPIBase: true` to skip validation of `OPENAI_API_BASE`. Required
+## API key and base URL
+
+`api_key` and `base_url` let you configure OpenAI API access without exporting
+`OPENAI_API_KEY` / `OPENAI_API_BASE` into your shell environment. The
+environment variables always take precedence when set — the config file is
+only consulted as a fallback. `base_url` is validated with the same rules as
+`OPENAI_API_BASE`; see [Query Models](usage/query-models.md#validation-rules).
+
+Since `config.yaml` would then contain your API key in plain text, restrict
+its permissions, e.g. `chmod 600 ~/.config/sgpt/config.yaml`.
+
+Set `insecureAPIBase: true` to skip validation of the base URL. Required
 for local LLM setups that point at a single-label LAN hostname (e.g.
 `http://thinkbox:8080/v1`); see [Query Models](usage/query-models.md#opt-out-for-lan-hostnames)
 for the validation rules.

--- a/docs/usage/query-models.md
+++ b/docs/usage/query-models.md
@@ -73,6 +73,11 @@ You can override the OpenAI base URL by setting the `OPENAI_API_BASE` environmen
 export OPENAI_API_BASE=https://api.openai.com/v1
 ```
 
+Alternatively, set `base_url` (and `api_key`) in `config.yaml` — see
+[Configuration](../configuration.md#api-key-and-base-url). The environment
+variable always takes precedence when set; the config file value is only used
+as a fallback.
+
 ### Validation rules
 
 To prevent an attacker-set environment variable from silently redirecting your

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -45,6 +45,8 @@ import (
 const (
 	// envKeyOpenAIApi is the environment variable key for the OpenAI API key.
 	envKeyOpenAIApi = "OPENAI_API_KEY"
+	// envKeyOpenAIApiBase is the environment variable key for the OpenAI API base URL.
+	envKeyOpenAIApiBase = "OPENAI_API_BASE"
 
 	// Defaults for the OpenAI HTTP client. Without these, sgpt inherits
 	// http.Client's zero value and can hang indefinitely when the
@@ -98,9 +100,14 @@ type OpenAIClient struct {
 // CreateClient creates a new OpenAI client with the given config and output writer.
 // Optional ClientOptions can be passed to override defaults (e.g. WithSessionManager).
 func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*OpenAIClient, error) {
-	// Check, if api key was set
-	apiKey, exists := os.LookupEnv(envKeyOpenAIApi)
-	if !exists {
+	// Check, if api key was set. The environment variable takes precedence;
+	// config.yaml (key "api_key") is a fallback for users who prefer not to
+	// export it into their shell environment (#228).
+	apiKey := os.Getenv(envKeyOpenAIApi)
+	if apiKey == "" && config != nil {
+		apiKey = config.GetString("api_key")
+	}
+	if apiKey == "" {
 		return nil, ErrMissingAPIKey
 	}
 	clientConfig := openai.DefaultConfig(apiKey)
@@ -122,11 +129,18 @@ func CreateClient(config *viper.Viper, out io.Writer, opts ...ClientOption) (*Op
 	// can redirect the Authorization header to an attacker-controlled host.
 	// The insecureAPIBase opt-out lets users with single-label LAN hostnames
 	// (e.g. http://thinkbox:8080/v1) bypass validation entirely.
+	// The environment variable takes precedence; config.yaml (key "base_url")
+	// is a fallback, and is validated the same way regardless of source (#228).
 	allowInsecure := false
 	if config != nil {
 		allowInsecure = config.GetBool("insecureAPIBase")
 	}
-	if baseURL, isSet := os.LookupEnv("OPENAI_API_BASE"); isSet {
+	baseURL, isSet := os.LookupEnv(envKeyOpenAIApiBase)
+	if !isSet && config != nil {
+		baseURL = config.GetString("base_url")
+		isSet = baseURL != ""
+	}
+	if isSet {
 		if err := validateAPIBaseURL(baseURL, allowInsecure); err != nil {
 			return nil, err
 		}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -66,6 +66,108 @@ func TestCreateClientMissingApiKey(t *testing.T) {
 	require.Nil(t, client)
 }
 
+func TestCreateClientApiKeyFromConfig(t *testing.T) {
+	// No OPENAI_API_KEY in the environment; the key comes from config.yaml
+	// (key "api_key") instead (#228).
+	prev, had := os.LookupEnv("OPENAI_API_KEY")
+	require.NoError(t, os.Unsetenv("OPENAI_API_KEY"))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENAI_API_KEY", prev)
+		}
+	})
+
+	v := viper.New()
+	v.Set("api_key", "from-config")
+
+	client, err := CreateClient(v, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestCreateClientApiKeyEnvOverridesConfig(t *testing.T) {
+	// Both the environment variable and config.yaml provide a key; the
+	// environment variable must win (#228).
+	t.Setenv("OPENAI_API_KEY", "from-env")
+
+	v := viper.New()
+	v.Set("api_key", "from-config")
+
+	client, err := CreateClient(v, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestCreateClientApiKeyEmptyEnvFallsBackToConfig(t *testing.T) {
+	// An OPENAI_API_KEY explicitly set to the empty string must not shadow
+	// a usable config.yaml value.
+	t.Setenv("OPENAI_API_KEY", "")
+
+	v := viper.New()
+	v.Set("api_key", "from-config")
+
+	client, err := CreateClient(v, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestCreateClientBaseURLFromConfig(t *testing.T) {
+	// No OPENAI_API_BASE in the environment; the base URL comes from
+	// config.yaml (key "base_url") instead, and is still validated (#228).
+	t.Setenv("OPENAI_API_KEY", "test")
+	prev, had := os.LookupEnv("OPENAI_API_BASE")
+	require.NoError(t, os.Unsetenv("OPENAI_API_BASE"))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENAI_API_BASE", prev)
+		}
+	})
+
+	v := viper.New()
+	v.Set("base_url", "https://api.openai.com/v1")
+
+	client, err := CreateClient(v, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestCreateClientBaseURLFromConfigRejectsUnsafeHost(t *testing.T) {
+	// A public http:// host from config.yaml goes through the same SSRF
+	// guard as the environment variable channel (#228).
+	t.Setenv("OPENAI_API_KEY", "test")
+	prev, had := os.LookupEnv("OPENAI_API_BASE")
+	require.NoError(t, os.Unsetenv("OPENAI_API_BASE"))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENAI_API_BASE", prev)
+		}
+	})
+
+	v := viper.New()
+	v.Set("base_url", "http://1.2.3.4/v1")
+
+	client, err := CreateClient(v, nil)
+	require.Error(t, err)
+	require.Nil(t, client)
+	require.Contains(t, err.Error(), "OPENAI_API_BASE")
+}
+
+func TestCreateClientBaseURLEnvOverridesConfig(t *testing.T) {
+	// Both the environment variable and config.yaml provide a base URL; the
+	// environment variable must win (#228). The config value would fail
+	// validation if it were the one applied, so a successful client proves
+	// the env value ("https://api.openai.com/v1") was used instead.
+	t.Setenv("OPENAI_API_KEY", "test")
+	t.Setenv("OPENAI_API_BASE", "https://api.openai.com/v1")
+
+	v := viper.New()
+	v.Set("base_url", "http://1.2.3.4/v1")
+
+	client, err := CreateClient(v, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
 func TestCreateClientAPIBaseValidation(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- `CreateClient` now falls back to `config.yaml` keys `api_key` and `base_url` when `OPENAI_API_KEY` / `OPENAI_API_BASE` are unset, so credentials no longer have to live in the shell environment.
- Environment variables still take precedence when set (including the existing "set but empty" edge case, which now falls through to the config value / `ErrMissingAPIKey` instead of silently proceeding with an empty key).
- A `base_url` sourced from config goes through the same `validateAPIBaseURL` SSRF guard as the environment variable (skippable via the existing `insecureAPIBase` opt-out).
- Docs updated: `docs/configuration.md` documents the new keys and recommends restrictive file permissions since the config file would then contain a plaintext API key; `docs/usage/query-models.md` cross-references the config-based alternative.

Closes #228

## Test plan
- [x] `go test ./pkg/api/... -v` — new tests: `TestCreateClientApiKeyFromConfig`, `TestCreateClientApiKeyEnvOverridesConfig`, `TestCreateClientApiKeyEmptyEnvFallsBackToConfig`, `TestCreateClientBaseURLFromConfig`, `TestCreateClientBaseURLFromConfigRejectsUnsafeHost`, `TestCreateClientBaseURLEnvOverridesConfig`; all existing `pkg/api` tests (including the `OPENAI_API_BASE` validation table) still pass.
- [x] `go test ./... -timeout=5m` — all pass except a pre-existing, unrelated Windows-only failure in `pkg/chat` (file permission bits), confirmed present on `main` before this change too.
- [x] `golangci-lint run --timeout=5m -c .golangci.yaml ./pkg/api/...` — 0 issues.
- [x] `goimports` applied to changed files.