### PR TITLE
test: close mutation-testing coverage gaps

### DIFF
--- a/pkg/chat/filesystem_test.go
+++ b/pkg/chat/filesystem_test.go
@@ -82,6 +82,11 @@ func TestValidateSessionNameValid(t *testing.T) {
 	}
 }
 
+func TestValidateSessionName_LengthBoundary(t *testing.T) {
+	require.NoError(t, validateSessionName(strings.Repeat("a", sessionNameMaxLength)))
+	require.ErrorIs(t, validateSessionName(strings.Repeat("a", sessionNameMaxLength+1)), ErrChatSessionNameTooLong)
+}
+
 func TestFilesystemChatSessionManager_SessionExists(t *testing.T) {
 	config := createTestConfig(t)
 

--- a/pkg/chat/filesystem_test.go
+++ b/pkg/chat/filesystem_test.go
@@ -24,6 +24,7 @@ package chat
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -310,6 +311,10 @@ func createTestConfig(t *testing.T) *viper.Viper {
 }
 
 func TestFilesystemChatSessionManager_SaveSession_FilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support POSIX permission bits; os.Stat().Mode().Perm() reports 0666 regardless of the mode passed to os.OpenFile")
+	}
+
 	config := createTestConfig(t)
 
 	manager, err := NewFilesystemChatSessionManager(config)

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -947,6 +947,21 @@ func TestLoadViperConfig_NoTestingFlag(t *testing.T) {
 	require.True(t, testCtx.Config.IsSet("cacheDir"))
 }
 
+func TestLoadViperConfig_MalformedConfigFile(t *testing.T) {
+	testCtx := testlib.NewTestCtx(t)
+
+	// A config file that exists but fails to parse must surface its error -
+	// only a missing file is swallowed by loadViperConfig.
+	configFile := filepath.Join(testCtx.ConfigDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("key: [unterminated"), 0o600))
+
+	err := loadViperConfig(testCtx.Config)
+	require.Error(t, err)
+
+	var notFoundErr viper.ConfigFileNotFoundError
+	require.NotErrorAs(t, err, &notFoundErr)
+}
+
 func TestRootCmd_TemplateWithPipedYAML(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -118,6 +118,15 @@ func TestReadString_LimitExceeded(t *testing.T) {
 	require.ErrorIs(t, err, ErrInputTooLarge)
 }
 
+func TestReadString_LimitBoundary(t *testing.T) {
+	// Exactly maxInputSize bytes must be accepted; the cap only rejects
+	// input strictly larger than the limit.
+	atLimit := strings.NewReader(strings.Repeat("a", maxInputSize))
+	out, err := ReadString(atLimit)
+	require.NoError(t, err)
+	require.Len(t, out, maxInputSize)
+}
+
 func TestReadString_TrailingAndCRLF(t *testing.T) {
 	// Characterizes the exact trimming behavior of the #377 rewrite:
 	// strings.TrimRight(data, "\r\n") strips *all* trailing line
@@ -288,6 +297,15 @@ func TestReadAll_LimitExceeded(t *testing.T) {
 	large := strings.NewReader(strings.Repeat("a", maxInputSize+1))
 	_, err := ReadAll(large)
 	require.ErrorIs(t, err, ErrInputTooLarge)
+}
+
+func TestReadAll_LimitBoundary(t *testing.T) {
+	// Exactly maxInputSize bytes must be accepted; the cap only rejects
+	// input strictly larger than the limit.
+	atLimit := strings.NewReader(strings.Repeat("a", maxInputSize))
+	out, err := ReadAll(atLimit)
+	require.NoError(t, err)
+	require.Len(t, out, maxInputSize)
 }
 
 func TestResolveUnderCwd_AcceptsFileInCwd(t *testing.T) {

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -376,6 +376,16 @@ func TestExecuteCommandWithConfirmation(t *testing.T) {
 	wg.Wait()
 }
 
+func TestExecuteCommandWithConfirmation_RefusesMultilineCommand(t *testing.T) {
+	// SanitizeCommand must run - and reject - before the user ever sees a
+	// confirmation prompt or getUserConfirmation reads from input; a hidden
+	// second line must never reach execution.
+	var out bytes.Buffer
+	err := ExecuteCommandWithConfirmation(context.Background(), strings.NewReader(""), &out, "echo test\nrm -rf /")
+	require.ErrorIs(t, err, ErrMultilineCommand)
+	require.Contains(t, out.String(), "Refusing to execute suggested command")
+}
+
 func TestSanitizeCommand_RemovesBidiOverrides(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Skip `TestFilesystemChatSessionManager_SaveSession_FilePermissions` on Windows: NTFS has no POSIX permission bits, so `os.Stat().Mode().Perm()` always reports 0666 there regardless of the mode passed to `os.OpenFile`, matching the existing `runtime.GOOS` skip convention used elsewhere in the test suite.
- Ran mutation testing (`mutest ./...`) across the module and added tests closing 5 of the 10 surviving mutants (score 80.8% -> 90.4%):
  - session name length boundary (exactly `sessionNameMaxLength` chars)
  - exact 1 MiB input boundary for `ReadString`/`ReadAll`
  - `ExecuteCommandWithConfirmation` refusing a multiline command before ever prompting the user
  - `loadViperConfig` surfacing a real parse error from a malformed (but present) config file, instead of only covering the "file not found" branch

The remaining 5 survivors are lower-value/hard-to-test without a refactor (an `os.Exit` path, an un-injectable clipboard-write failure, a near-unreachable filesystem-root recursion base case, and two log-only fallback branches) and were left as-is.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -timeout=5m`
- [x] `mutest ./...` re-run confirming score improvement and no regressions