### PR TITLE
fix(api): use MaxCompletionTokens instead of deprecated MaxTokens (#393)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -242,12 +242,12 @@ func (c *OpenAIClient) CreateCompletion(ctx context.Context, chatID string, prom
 
 	// Create request
 	req := openai.ChatCompletionRequest{
-		Messages:    messages,
-		Model:       c.config.GetString("model"),
-		MaxTokens:   c.config.GetInt("max-tokens"),
-		Temperature: float32(c.config.GetFloat64("temperature")),
-		TopP:        float32(c.config.GetFloat64("top-p")),
-		Stream:      c.config.GetBool("stream"),
+		Messages:            messages,
+		Model:               c.config.GetString("model"),
+		MaxCompletionTokens: c.config.GetInt("max-tokens"),
+		Temperature:         float32(c.config.GetFloat64("temperature")),
+		TopP:                float32(c.config.GetFloat64("top-p")),
+		Stream:              c.config.GetBool("stream"),
 	}
 
 	// Retrieve response

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -24,7 +24,9 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -189,6 +191,52 @@ func TestSimplePrompt(t *testing.T) {
 	require.NoError(t, err)
 
 	wg.Wait()
+}
+
+func TestSimplePromptSendsMaxCompletionTokens(t *testing.T) {
+	testCtx := testlib.NewTestCtx(t)
+	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
+	testCtx.Config.Set("max-tokens", 512)
+
+	client, err := CreateClient(testCtx.Config, io.Discard)
+	require.NoError(t, err)
+
+	httpmock.ActivateNonDefault(client.HTTPClient)
+	t.Cleanup(httpmock.DeactivateAndReset)
+
+	var capturedBody []byte
+	httpmock.RegisterResponder(
+		"POST",
+		"https://api.openai.com/v1/chat/completions",
+		func(req *http.Request) (*http.Response, error) {
+			var readErr error
+			capturedBody, readErr = io.ReadAll(req.Body)
+			if readErr != nil {
+				return nil, readErr
+			}
+			return httpmock.NewStringResponse(200, `{
+				"choices": [
+					{
+						"index": 0,
+						"finish_reason": "length",
+						"message": {
+							"role": "assistant",
+							"content": "Hello World!"
+						}
+					}
+				]
+			}`), nil
+		},
+	)
+
+	_, err = client.CreateCompletion(context.Background(), "", []string{"Say: Hello World!"}, "txt", nil)
+	require.NoError(t, err)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &payload))
+	require.Equal(t, float64(512), payload["max_completion_tokens"])
+	require.NotContains(t, payload, "max_tokens")
 }
 
 func TestStreamSimplePrompt(t *testing.T) {


### PR DESCRIPTION
## Summary
- `openai.ChatCompletionRequest.MaxTokens` was deprecated in `go-openai` v1.42.0 (SA1019), causing `golangci-lint` to fail on every push since that dependency bump.
- Switches `pkg/api/api.go` to set `MaxCompletionTokens` instead, which has the same semantics and is the field the OpenAI API now expects.

## Why
Fixes the CI lint failure described in #393 (`pkg/api/api.go:247: SA1019`).

## Test plan
- [x] Added `TestSimplePromptSendsMaxCompletionTokens`, which asserts the outgoing request body sets `max_completion_tokens` and omits `max_tokens`; verified it fails against the old code and passes against the fix
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m -c .golangci.yaml ./pkg/api/...` — 0 issues

Closes #393