### PR TITLE
fix(api): use correct viper keys for maxTokens and topP (#395)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -244,9 +244,9 @@ func (c *OpenAIClient) CreateCompletion(ctx context.Context, chatID string, prom
 	req := openai.ChatCompletionRequest{
 		Messages:            messages,
 		Model:               c.config.GetString("model"),
-		MaxCompletionTokens: c.config.GetInt("max-tokens"),
+		MaxCompletionTokens: c.config.GetInt("maxTokens"),
 		Temperature:         float32(c.config.GetFloat64("temperature")),
-		TopP:                float32(c.config.GetFloat64("top-p")),
+		TopP:                float32(c.config.GetFloat64("topP")),
 		Stream:              c.config.GetBool("stream"),
 	}
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -197,7 +197,7 @@ func TestSimplePromptSendsMaxCompletionTokens(t *testing.T) {
 	testCtx := testlib.NewTestCtx(t)
 	testlib.SetAPIKey(t)
 	testlib.SetAPIBase(t)
-	testCtx.Config.Set("max-tokens", 512)
+	testCtx.Config.Set("maxTokens", 512)
 
 	client, err := CreateClient(testCtx.Config, io.Discard)
 	require.NoError(t, err)
@@ -237,6 +237,51 @@ func TestSimplePromptSendsMaxCompletionTokens(t *testing.T) {
 	require.NoError(t, json.Unmarshal(capturedBody, &payload))
 	require.Equal(t, float64(512), payload["max_completion_tokens"])
 	require.NotContains(t, payload, "max_tokens")
+}
+
+func TestSimplePromptSendsTopP(t *testing.T) {
+	testCtx := testlib.NewTestCtx(t)
+	testlib.SetAPIKey(t)
+	testlib.SetAPIBase(t)
+	testCtx.Config.Set("topP", 0.5)
+
+	client, err := CreateClient(testCtx.Config, io.Discard)
+	require.NoError(t, err)
+
+	httpmock.ActivateNonDefault(client.HTTPClient)
+	t.Cleanup(httpmock.DeactivateAndReset)
+
+	var capturedBody []byte
+	httpmock.RegisterResponder(
+		"POST",
+		"https://api.openai.com/v1/chat/completions",
+		func(req *http.Request) (*http.Response, error) {
+			var readErr error
+			capturedBody, readErr = io.ReadAll(req.Body)
+			if readErr != nil {
+				return nil, readErr
+			}
+			return httpmock.NewStringResponse(200, `{
+				"choices": [
+					{
+						"index": 0,
+						"finish_reason": "length",
+						"message": {
+							"role": "assistant",
+							"content": "Hello World!"
+						}
+					}
+				]
+			}`), nil
+		},
+	)
+
+	_, err = client.CreateCompletion(context.Background(), "", []string{"Say: Hello World!"}, "txt", nil)
+	require.NoError(t, err)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &payload))
+	require.Equal(t, float64(0.5), payload["top_p"])
 }
 
 func TestStreamSimplePrompt(t *testing.T) {


### PR DESCRIPTION
## Summary
`pkg/api/api.go` read the `--max-tokens`/`--top-p` values back from viper using the kebab-case flag names, but `pkg/cli/root.go` binds and defaults them under the camelCase keys `maxTokens`/`topP`. Viper treats these as unrelated keys, so `GetInt("max-tokens")`/`GetFloat64("top-p")` always returned the zero value, silently dropping the flags (and their config-file/env equivalents) from the request.

## Why
Fixes #395. `MaxCompletionTokens`/`TopP` now read from the keys that are actually bound (`maxTokens`/`topP`), matching how `model`, `temperature`, and `stream` are already handled.

## Test plan
- [x] Updated `TestSimplePromptSendsMaxCompletionTokens` to set `maxTokens` (the real bound key) — fails before the fix, passes after
- [x] Added `TestSimplePromptSendsTopP` covering the same issue for `top-p`
- [x] `go test ./... -timeout=5m` — all green
- [x] `golangci-lint run` on touched files — 0 issues

Closes #395