### PR TITLE
fix(ci): bump go directive to 1.26.8 to resolve govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tbckr/sgpt/v2
 
-go 1.26.5
+go 1.26.8
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
## Summary
- `go.mod` pinned `go 1.26.5`, whose standard library carries 4 known CVEs (net/url, crypto/tls, encoding/asn1, net/http/idna) that are fixed in 1.26.6+
- CI installs the Go toolchain via `go-version-file: go.mod`, so it always picked up the vulnerable stdlib, failing the `vuln_check` job (see run for #396: https://github.com/tbckr/sgpt/actions/runs/33793717044/job/100776232774?pr=396)
- Bump the `go` directive to `1.26.8` (latest patch release) so CI installs an unaffected toolchain

Closes #397

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -timeout=5m` — all packages pass
- [x] `govulncheck ./...` (rebuilt with go1.27.1) — 0 vulnerabilities found, was 4 before the bump